### PR TITLE
Add split screen for foldables (continuation)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,6 +172,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.8.0'
     implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+    implementation 'androidx.window:window:1.0.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.5.1"
     implementation 'androidx.fragment:fragment-ktx:1.5.5'

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -130,19 +130,6 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
 
     private var gameSurface : Surface? = null
 
-    private val displayHeight by lazy {
-        with (windowManager) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                maximumWindowMetrics.bounds.height()
-            } else {
-                val displayMetrics = DisplayMetrics()
-                @Suppress("DEPRECATION")
-                defaultDisplay.getMetrics(displayMetrics)
-                displayMetrics.heightPixels
-            }
-        }
-    }
-
     /**
      * This is the entry point into the emulation code for libskyline
      *
@@ -520,15 +507,15 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     * Updating the layout depending on type and state of device
     */
     private fun updateCurrentLayout(newLayoutInfo: WindowLayoutInfo) {
-        binding.onScreenGameView.minimumHeight = displayHeight
         if (!emulationSettings.supportFoldableScreen) return
+        binding.onScreenGameView.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
         requestedOrientation = emulationSettings.orientation
         val foldingFeature = newLayoutInfo.displayFeatures.find { it is FoldingFeature }
         (foldingFeature as? FoldingFeature)?.let {
             if (it.isSeparating) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
                 if (it.orientation == FoldingFeature.Orientation.HORIZONTAL)
-                    binding.onScreenGameView.minimumHeight = it.bounds.top
+                    binding.onScreenGameView.layoutParams.height = it.bounds.top
             }
         }
     }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -511,14 +511,21 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         val displayMetrics = DisplayMetrics()
         windowManager.defaultDisplay.getMetrics(displayMetrics)
         binding.onScreenGameView.minimumHeight = displayMetrics.heightPixels
-        requestedOrientation = emulationSettings.orientation
+        requestedOrientation =
+            if (emulationSettings.orientation != ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
+                emulationSettings.orientation
+            } else {
+                ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            }
         for (displayFeature in newLayoutInfo.displayFeatures) {
             val foldFeature = displayFeature as? FoldingFeature
             foldFeature?.let {
+                //Folding feature separates the display area into two distinct sections
                 if (it.isSeparating) {
-                    //Folding feature separates the display area into two distinct sections
-                    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-                    if (foldFeature.orientation == FoldingFeature.Orientation.HORIZONTAL) {
+                    if (emulationSettings.orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED){
+                        requestedOrientation = emulationSettings.orientation
+                    }
+                    if (it.orientation == FoldingFeature.Orientation.HORIZONTAL) {
                         binding.onScreenGameView.minimumHeight = displayFeature.bounds.top
                     }
                 }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -289,6 +289,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         populateAppItem()
         emulationSettings = EmulationSettings.forEmulation(item.titleId ?: item.key())
 
+        requestedOrientation = emulationSettings.orientation
         window.attributes.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
         inputHandler = InputHandler(inputManager, emulationSettings)
         setContentView(binding.root)
@@ -519,9 +520,9 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     * Updating the layout depending on type and state of device
     */
     private fun updateCurrentLayout(newLayoutInfo: WindowLayoutInfo) {
-        requestedOrientation = emulationSettings.orientation
         binding.onScreenGameView.minimumHeight = displayHeight
         if (!emulationSettings.supportFoldableScreen) return
+        requestedOrientation = emulationSettings.orientation
         val foldingFeature = newLayoutInfo.displayFeatures.find { it is FoldingFeature }
         (foldingFeature as? FoldingFeature)?.let {
             if (it.isSeparating) {

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -519,17 +519,15 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
     * Updating the layout depending on type and state of device
     */
     private fun updateCurrentLayout(newLayoutInfo: WindowLayoutInfo) {
+        requestedOrientation = emulationSettings.orientation
+        binding.onScreenGameView.minimumHeight = displayHeight
         if (!emulationSettings.supportFoldableScreen) return
         val foldingFeature = newLayoutInfo.displayFeatures.find { it is FoldingFeature }
         (foldingFeature as? FoldingFeature)?.let {
-            binding.onScreenGameView.minimumHeight = displayHeight
-            requestedOrientation = emulationSettings.orientation
             if (it.isSeparating) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
                 if (it.orientation == FoldingFeature.Orientation.HORIZONTAL)
                     binding.onScreenGameView.minimumHeight = it.bounds.top
-                else
-                    requestedOrientation = emulationSettings.orientation
             }
         }
     }

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -516,21 +516,21 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
             if (it.isSeparating) {
                 requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
                 if (it.orientation == FoldingFeature.Orientation.HORIZONTAL) {
-                    binding.onScreenGameView.layoutParams.height = it.bounds.top
-                    binding.controllerViewContainer.layoutParams.height = it.bounds.bottom - 48.toPx
-                    binding.controllerViewContainer.updatePadding(0, 0, 0, 24.toPx)
+                    binding.gameViewContainer.layoutParams.height = it.bounds.top
+                    binding.overlayViewContainer.layoutParams.height = it.bounds.bottom - 48.toPx
+                    binding.overlayViewContainer.updatePadding(0, 0, 0, 24.toPx)
                 }
             }
             it.isSeparating
         } ?: false
         if (!isFolding) {
-            binding.onScreenGameView.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
-            binding.controllerViewContainer.updatePadding(0, 0, 0, 0)
-            binding.controllerViewContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            binding.gameViewContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
+            binding.overlayViewContainer.updatePadding(0, 0, 0, 0)
+            binding.overlayViewContainer.layoutParams.height = ViewGroup.LayoutParams.MATCH_PARENT
             requestedOrientation = emulationSettings.orientation
         }
-        binding.onScreenGameView.requestLayout()
-        binding.controllerViewContainer.requestLayout()
+        binding.gameViewContainer.requestLayout()
+        binding.overlayViewContainer.requestLayout()
     }
 
     /**

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -518,6 +518,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
                     binding.onScreenGameView.layoutParams.height = it.bounds.top
             }
         }
+        binding.onScreenGameView.requestLayout()
     }
 
     /**

--- a/app/src/main/java/emu/skyline/settings/EmulationSettings.kt
+++ b/app/src/main/java/emu/skyline/settings/EmulationSettings.kt
@@ -40,6 +40,7 @@ class EmulationSettings private constructor(context : Context, prefName : String
     var orientation by sharedPreferences(context, ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE, prefName = prefName)
     var aspectRatio by sharedPreferences(context, 0, prefName = prefName)
     var respectDisplayCutout by sharedPreferences(context, false, prefName = prefName)
+    var supportFoldableScreen by sharedPreferences(context, false, prefName = prefName)
 
     // GPU
     var gpuDriver by sharedPreferences(context, SYSTEM_GPU_DRIVER, prefName = prefName)

--- a/app/src/main/java/emu/skyline/settings/EmulationSettings.kt
+++ b/app/src/main/java/emu/skyline/settings/EmulationSettings.kt
@@ -40,7 +40,7 @@ class EmulationSettings private constructor(context : Context, prefName : String
     var orientation by sharedPreferences(context, ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE, prefName = prefName)
     var aspectRatio by sharedPreferences(context, 0, prefName = prefName)
     var respectDisplayCutout by sharedPreferences(context, false, prefName = prefName)
-    var supportFoldableScreen by sharedPreferences(context, false, prefName = prefName)
+    var enableFoldableLayout by sharedPreferences(context, false, prefName = prefName)
 
     // GPU
     var gpuDriver by sharedPreferences(context, SYSTEM_GPU_DRIVER, prefName = prefName)

--- a/app/src/main/java/emu/skyline/settings/GlobalSettingsFragment.kt
+++ b/app/src/main/java/emu/skyline/settings/GlobalSettingsFragment.kt
@@ -11,12 +11,19 @@ import android.view.View
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import androidx.preference.TwoStatePreference
+import androidx.window.layout.FoldingFeature
+import androidx.window.layout.WindowInfoTracker
 import emu.skyline.BuildConfig
 import emu.skyline.MainActivity
 import emu.skyline.R
 import emu.skyline.utils.GpuDriverHelper
 import emu.skyline.utils.WindowInsetsHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * This fragment is used to display the global preferences
@@ -42,6 +49,14 @@ class GlobalSettingsFragment : PreferenceFragmentCompat() {
             requireActivity().finishAffinity()
             startActivity(Intent(requireContext(), MainActivity::class.java))
             true
+        }
+
+        CoroutineScope(Dispatchers.IO).launch {
+            WindowInfoTracker.getOrCreate(requireContext()).windowLayoutInfo(requireActivity()).collect { newLayoutInfo ->
+                withContext(Dispatchers.Main) {
+                    findPreference<SwitchPreferenceCompat>("enable_foldable_layout")?.isVisible = newLayoutInfo.displayFeatures.find { it is FoldingFeature } != null
+                }
+            }
         }
 
         // Uncheck `disable_frame_throttling` if `force_triple_buffering` gets disabled

--- a/app/src/main/res/layout/emu_activity.xml
+++ b/app/src/main/res/layout/emu_activity.xml
@@ -9,11 +9,17 @@
     tools:context=".EmulationActivity"
     tools:ignore="RtlHardcoded">
 
-    <emu.skyline.views.FixedRatioSurfaceView
-        android:id="@+id/game_view"
+    <FrameLayout
+        android:id="@+id/on_screen_game_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center" />
+        android:layout_height="wrap_content">
+
+        <emu.skyline.views.FixedRatioSurfaceView
+            android:id="@+id/game_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+    </FrameLayout>
 
     <emu.skyline.input.onscreen.OnScreenControllerView
         android:id="@+id/on_screen_controller_view"

--- a/app/src/main/res/layout/emu_activity.xml
+++ b/app/src/main/res/layout/emu_activity.xml
@@ -21,47 +21,54 @@
             android:layout_gravity="center" />
     </FrameLayout>
 
-    <emu.skyline.input.onscreen.OnScreenControllerView
-        android:id="@+id/on_screen_controller_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-    <TextView
-        android:id="@+id/perf_stats"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top|left"
-        android:layout_marginLeft="@dimen/onScreenItemHorizontalMargin"
-        android:layout_marginTop="5dp"
-        android:textColor="@color/colorPerfStatsPrimary"
-        tools:text="60 FPS\n16.6±0.10ms" />
-
-    <ImageButton
-        android:id="@+id/on_screen_pause_toggle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top|right"
-        android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
-        android:background="?android:attr/actionBarItemBackground"
-        android:padding="8dp"
-        android:src="@drawable/ic_pause"
-        app:tint="#40FFFFFF"
-        tools:ignore="ContentDescription" />
-
-    <ImageButton
-        android:id="@+id/on_screen_controller_toggle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom|right"
-        android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
-        android:background="?android:attr/actionBarItemBackground"
-        android:padding="8dp"
-        android:src="@drawable/ic_show"
-        app:tint="#40FFFFFF"
-        tools:ignore="ContentDescription" />
-
     <FrameLayout
-        android:id="@+id/emulation_fragment"
+        android:id="@+id/controller_view_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_gravity="bottom">
+
+        <emu.skyline.input.onscreen.OnScreenControllerView
+            android:id="@+id/on_screen_controller_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@+id/perf_stats"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|left"
+            android:layout_marginLeft="@dimen/onScreenItemHorizontalMargin"
+            android:layout_marginTop="5dp"
+            android:textColor="@color/colorPerfStatsPrimary"
+            tools:text="60 FPS\n16.6±0.10ms" />
+
+        <ImageButton
+            android:id="@+id/on_screen_pause_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="top|right"
+            android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
+            android:background="?android:attr/actionBarItemBackground"
+            android:padding="8dp"
+            android:src="@drawable/ic_pause"
+            app:tint="#40FFFFFF"
+            tools:ignore="ContentDescription" />
+
+        <ImageButton
+            android:id="@+id/on_screen_controller_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|right"
+            android:layout_marginRight="@dimen/onScreenItemHorizontalMargin"
+            android:background="?android:attr/actionBarItemBackground"
+            android:padding="8dp"
+            android:src="@drawable/ic_show"
+            app:tint="#40FFFFFF"
+            tools:ignore="ContentDescription" />
+
+        <FrameLayout
+            android:id="@+id/emulation_fragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </FrameLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/emu_activity.xml
+++ b/app/src/main/res/layout/emu_activity.xml
@@ -10,9 +10,9 @@
     tools:ignore="RtlHardcoded">
 
     <FrameLayout
-        android:id="@+id/on_screen_game_view"
+        android:id="@+id/game_view_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <emu.skyline.views.FixedRatioSurfaceView
             android:id="@+id/game_view"
@@ -22,7 +22,7 @@
     </FrameLayout>
 
     <FrameLayout
-        android:id="@+id/controller_view_container"
+        android:id="@+id/overlay_view_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="bottom">

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -85,14 +85,12 @@
         <item>Device Aspect Ratio (Stretch to fit)</item>
     </string-array>
     <string-array name="orientation_entries">
-        <item>Landscape (auto)</item>
         <item>Auto</item>
         <item>Landscape</item>
         <item>Landscape (reverse)</item>
     </string-array>
     <integer-array name="orientation_values">
         <item>6</item>
-        <item>-1</item>
         <item>0</item>
         <item>8</item>
     </integer-array>

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -85,12 +85,14 @@
         <item>Device Aspect Ratio (Stretch to fit)</item>
     </string-array>
     <string-array name="orientation_entries">
+        <item>Landscape (auto)</item>
         <item>Auto</item>
         <item>Landscape</item>
         <item>Landscape (reverse)</item>
     </string-array>
     <integer-array name="orientation_values">
         <item>6</item>
+        <item>-1</item>
         <item>0</item>
         <item>8</item>
     </integer-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,9 @@
     <string name="respect_display_cutout">Respect Display Cutout</string>
     <string name="respect_display_cutout_enabled">Do not draw UI elements in the cutout area</string>
     <string name="respect_display_cutout_disabled">Allow UI elements to be drawn in the cutout area</string>
+    <string name="support_foldable_screen">Support Foldable Screens</string>
+    <string name="support_foldable_screen_enabled">Folded devices will display game and controller separately</string>
+    <string name="support_foldable_screen_disabled">Display controller over games even when device is folded</string>
     <!-- Settings - Audio -->
     <string name="audio">Audio</string>
     <string name="disable_audio_output">Disable Audio Output</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,9 +94,9 @@
     <string name="respect_display_cutout">Respect Display Cutout</string>
     <string name="respect_display_cutout_enabled">Do not draw UI elements in the cutout area</string>
     <string name="respect_display_cutout_disabled">Allow UI elements to be drawn in the cutout area</string>
-    <string name="support_foldable_screen">Support Foldable Screens</string>
-    <string name="support_foldable_screen_enabled">Folded devices will display game and controller separately</string>
-    <string name="support_foldable_screen_disabled">Display controller over games even when device is folded</string>
+    <string name="enable_foldable_layout">Enable Foldable Layout</string>
+    <string name="enable_foldable_layout_enabled">Folded devices will display game and controller separately</string>
+    <string name="enable_foldable_layout_disabled">Display controller over games even when device is folded</string>
     <!-- Settings - Audio -->
     <string name="audio">Audio</string>
     <string name="disable_audio_output">Disable Audio Output</string>

--- a/app/src/main/res/xml/emulation_preferences.xml
+++ b/app/src/main/res/xml/emulation_preferences.xml
@@ -72,6 +72,12 @@
             android:summaryOn="@string/respect_display_cutout_enabled"
             app:key="respect_display_cutout"
             app:title="@string/respect_display_cutout" />
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:summaryOff="@string/support_foldable_screen_disabled"
+            android:summaryOn="@string/support_foldable_screen_enabled"
+            app:key="support_foldable_screen"
+            app:title="@string/support_foldable_screen" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="category_audio"

--- a/app/src/main/res/xml/emulation_preferences.xml
+++ b/app/src/main/res/xml/emulation_preferences.xml
@@ -74,10 +74,11 @@
             app:title="@string/respect_display_cutout" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
-            android:summaryOff="@string/support_foldable_screen_disabled"
-            android:summaryOn="@string/support_foldable_screen_enabled"
-            app:key="support_foldable_screen"
-            app:title="@string/support_foldable_screen" />
+            android:summaryOff="@string/enable_foldable_layout_disabled"
+            android:summaryOn="@string/enable_foldable_layout_enabled"
+            app:key="enable_foldable_layout"
+            app:title="@string/enable_foldable_layout"
+            app:isPreferenceVisible="false"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="category_audio"


### PR DESCRIPTION
While you guys were on a break, I fixed the fundamental problem with the original PR. Now the option only appears on a foldable device. Doing that, the setting can now be named something less obscure.