### PR TITLE
Implement GetApplicationAreaSize

### DIFF
--- a/app/src/main/cpp/skyline/services/nfp/IUser.cpp
+++ b/app/src/main/cpp/skyline/services/nfp/IUser.cpp
@@ -23,6 +23,11 @@ namespace skyline::service::nfp {
         return {};
     }
 
+    Result IUser::GetApplicationAreaSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
+        response.Push<u32>(0xD8); // 216 bytes
+        return {};
+    }
+
     Result IUser::AttachAvailabilityChangeEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response) {
         auto handle{state.process->InsertItem(attachAvailabilityChangeEvent)};
         Logger::Debug("Attach Availability Change Event Handle: 0x{:X}", handle);

--- a/app/src/main/cpp/skyline/services/nfp/IUser.h
+++ b/app/src/main/cpp/skyline/services/nfp/IUser.h
@@ -36,6 +36,11 @@ namespace skyline::service::nfp {
         Result GetState(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
 
         /*
+         * @url https://switchbrew.org/wiki/NFC_services#GetApplicationAreaSize
+         */
+        Result GetApplicationAreaSize(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
+
+        /*
          * @url https://switchbrew.org/wiki/NFC_services#AttachAvailabilityChangeEvent
          */
         Result AttachAvailabilityChangeEvent(type::KSession &session, ipc::IpcRequest &request, ipc::IpcResponse &response);
@@ -43,8 +48,9 @@ namespace skyline::service::nfp {
         SERVICE_DECL(
             SFUNC(0x0, IUser, Initialize),
             SFUNC(0x2, IUser, ListDevices),
-            SFUNC(0x13, IUser, GetState),
-            SFUNC(0x17, IUser, AttachAvailabilityChangeEvent)
+            SFUNC(0x19, IUser, GetState),
+            SFUNC(0x22, IUser, GetApplicationAreaSize),
+            SFUNC(0x23, IUser, AttachAvailabilityChangeEvent)
         )
     };
 }


### PR DESCRIPTION
This defines the amiibo app data size, which is a constant 216 byte region. This also fixes a few service declarations for other methods.