### PR TITLE
Handle unchangeable memory attributes better

### DIFF
--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -63,8 +63,8 @@ namespace skyline::kernel::svc {
         }
 
         if (!chunk->state.attributeChangeAllowed) {
-            state.ctx->gpr.w0 = result::InvalidState;
             Logger::Warn("Attribute change not allowed for chunk: 0x{:X}", pointer);
+            state.ctx->gpr.w0 = Result{};
             return;
         }
 


### PR DESCRIPTION
If a memory chunk doesn't allow changing its attributes, we just don't change them instead of telling the game. This allows Metroid Prime Remastered to boot.