### PR TITLE
Export custom settings to text

### DIFF
--- a/app/src/main/java/emu/skyline/preference/ExportCustomSettingsPreference.kt
+++ b/app/src/main/java/emu/skyline/preference/ExportCustomSettingsPreference.kt
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: MPL-2.0
+ * Copyright © 2023 Strato Team and Contributors (https://github.com/strato-emu/)
+ */
+
+package emu.skyline.preference
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import android.content.ClipData
+import android.content.ClipboardManager
+import emu.skyline.settings.EmulationSettings
+
+/**
+ * Shows a dialog to copy the current game's custom settings (or the global settings if customs are disabled) so they
+ * can be easily shareable in Discord or other places
+ */
+class ExportCustomSettingsPreference @JvmOverloads constructor(context : Context, attrs : AttributeSet? = null, defStyleAttr : Int = androidx.preference.R.attr.preferenceStyle) : Preference(context, attrs, defStyleAttr) {
+
+    init {
+        setOnPreferenceClickListener {
+            var emulationSettings = EmulationSettings.forPrefName(preferenceManager.sharedPreferencesName)
+
+            if (!emulationSettings.useCustomSettings) {
+                emulationSettings = EmulationSettings.global
+            }
+
+            val systemIsDocked = emulationSettings.isDocked;
+
+            val gpuDriver = emulationSettings.gpuDriver;
+            val gpuTripleBuffering = emulationSettings.forceTripleBuffering;
+            val gpuExecSlotCount = emulationSettings.executorSlotCountScale
+            val gpuExecFlushThreshold = emulationSettings.executorFlushThreshold;
+            val gpuDMI = emulationSettings.useDirectMemoryImport;
+            val gpuFreeGuestTextureMemory = emulationSettings.freeGuestTextureMemory;
+            val gpuDisableShaderCache = emulationSettings.disableShaderCache;
+            val gpuForceMaxGpuClocks = emulationSettings.forceMaxGpuClocks
+
+            val hackFastGpuReadback = emulationSettings.enableFastGpuReadbackHack;
+            val hackFastReadbackWrite = emulationSettings.enableFastReadbackWrites;
+            val hackDisableSubgroupShuffle = emulationSettings.disableSubgroupShuffle;
+
+            val settingsAsText = String.format(
+                """
+                SYSTEM
+                - Docked: $systemIsDocked
+                
+                GPU
+                - Driver: $gpuDriver
+                - Executors: $gpuExecSlotCount slots (threshold: $gpuExecFlushThreshold)
+                - Triple buffering: $gpuTripleBuffering, DMI: $gpuDMI
+                - Max clocks: $gpuForceMaxGpuClocks, free guest texture memory: $gpuFreeGuestTextureMemory
+                - Disable shader cache: $gpuDisableShaderCache
+                
+                HACKS
+                - Fast GPU readback: $hackFastGpuReadback, fast readback writes $hackFastReadbackWrite
+                - Disable GPU subgroup shuffle: $hackDisableSubgroupShuffle
+                """.trimIndent().replace("true", "✔").replace("false", "✖")
+            )
+
+            MaterialAlertDialogBuilder(context)
+                .setTitle(title)
+                .setMessage(settingsAsText)
+                .setPositiveButton(android.R.string.copy) { _, _ ->
+                    // Copy the current settings as text to the system clipboard
+                    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                    val clip = ClipData.newPlainText("label", settingsAsText)
+                    clipboard.setPrimaryClip(clip)
+
+                }
+                .setNegativeButton(android.R.string.ok, null)
+                .show()
+
+            true
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,6 +64,8 @@
     <string name="use_custom_settings">Enable Custom Settings</string>
     <string name="use_custom_settings_desc_on">Custom settings are enabled for this game</string>
     <string name="use_custom_settings_desc_off">Custom settings are disabled for this game</string>
+    <string name="export_custom_settings">Export custom settings to text</string>
+    <string name="export_custom_settings_desc">Copy a text with your current settings to share online</string>
     <string name="reset_custom_settings">Reset Custom Settings</string>
     <string name="reset_custom_settings_desc">Reset custom settings to the default values</string>
     <string name="reset_settings_warning">Are you sure you want to reset all settings to the default values? <b>Current settings will be lost</b></string>

--- a/app/src/main/res/xml/custom_game_preferences.xml
+++ b/app/src/main/res/xml/custom_game_preferences.xml
@@ -9,6 +9,10 @@
             android:summaryOn="@string/use_custom_settings_desc_on"
             app:key="use_custom_settings"
             app:title="@string/use_custom_settings" />
+        <emu.skyline.preference.ExportCustomSettingsPreference
+            android:summary="@string/export_custom_settings_desc"
+            app:key="@string/export_custom_settings"
+            app:title="@string/export_custom_settings" />
         <emu.skyline.preference.ResetSettingsPreference
             android:summary="@string/reset_custom_settings_desc"
             app:key="reset_custom_settings"


### PR DESCRIPTION
Copied my original PR from Skyline (https://github.com/skyline-emu/skyline/pull/2346):

Created a very simple function to export a game's custom settings (or global settings if custom are disabled) to text, so users can then easily share their configs in Discord (the button placement can be seen in the background of the screenshot as well):

![image](https://github.com/strato-emu/strato/assets/17100634/db9d2c96-4583-4ccc-bd63-f0d5719cb3d1)

If you are not a fan of ascii emojis, i could always just replace then by ON/OFF as well