### PR TITLE
Auto-hide OSD for Joystick input sources only

### DIFF
--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -649,14 +649,12 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         deviceIds.forEach { deviceId ->
             InputDevice.getDevice(deviceId).apply {
                 // Verify that the device has gamepad buttons, control sticks, or both.
-                if (sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
-                    || sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK) {
+                if (sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK) {
                     // This device is a game controller.
                     return true
                 }
             }
         }
-
         return false
     }
 


### PR DESCRIPTION
Checking for the Gamepad input source caused false positives for some ROMs where the virtual keyboard is reported as a gamepad. #146 