### PR TITLE
build: Change-app-name-Skyline-to-Strato

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,10 +17,10 @@ android {
     namespace 'emu.skyline'
     compileSdk 33
 
-    var isBuildSigned = (System.getenv("CI") == "true") && (System.getenv("IS_SKYLINE_SIGNED") == "true")
+    var isBuildSigned = (System.getenv("CI") == "true") && (System.getenv("IS_STRATO_SIGNED") == "true")
 
     defaultConfig {
-        applicationId "skyline.emu"
+        applicationId "strato.emu"
 
         minSdk 29
         targetSdk 33
@@ -112,14 +112,14 @@ android {
     productFlavors {
         full {
             dimension = "version"
-            manifestPlaceholders += [appLabel: "Skyline"]
+            manifestPlaceholders += [appLabel: "Strato"]
         }
 
         dev {
             dimension = "version"
             applicationIdSuffix = ".dev"
             versionNameSuffix = "-dev"
-            manifestPlaceholders += [appLabel: "Skyline Dev"]
+            manifestPlaceholders += [appLabel: "Strato Dev"]
         }
     }
 

--- a/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.cpp
+++ b/app/src/main/cpp/skyline/applet/swkbd/software_keyboard_applet.cpp
@@ -41,7 +41,7 @@ namespace skyline::applet::swkbd {
     }
 
     static std::u16string FillDefaultText(u32 minLength, u32 maxLength) {
-        std::u16string text{u"Skyline"};
+        std::u16string text{u"Strato"};
         while (text.size() < minLength)
             text += u"Emulator" + text;
         if (text.size() > maxLength)

--- a/app/src/main/cpp/skyline/gpu.cpp
+++ b/app/src/main/cpp/skyline/gpu.cpp
@@ -11,7 +11,7 @@
 namespace skyline::gpu {
     static vk::raii::Instance CreateInstance(const DeviceState &state, const vk::raii::Context &context) {
         vk::ApplicationInfo applicationInfo{
-            .pApplicationName = "Skyline",
+            .pApplicationName = "Strato",
             .applicationVersion = static_cast<uint32_t>(state.jvm->GetVersionCode()), // Get the application version from JNI
             .pEngineName = "FTX1", // "Fast Tegra X1"
             .apiVersion = VkApiVersion,

--- a/app/src/main/java/emu/skyline/EmulationActivity.kt
+++ b/app/src/main/java/emu/skyline/EmulationActivity.kt
@@ -196,7 +196,7 @@ class EmulationActivity : AppCompatActivity(), SurfaceHolder.Callback, View.OnTo
         // Hack for MIUI devices since they don't support the standard Android APIs
         try {
             val setFpsIntent = Intent("com.miui.powerkeeper.SET_ACTIVITY_FPS")
-            setFpsIntent.putExtra("package_name", "skyline.emu")
+            setFpsIntent.putExtra("package_name", "strato.emu")
             setFpsIntent.putExtra("isEnter", enable)
             sendBroadcast(setFpsIntent)
         } catch (_ : Exception) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name" translatable="false">Skyline</string>
+    <string name="app_name" translatable="false">Strato</string>
     <!-- Common -->
     <string name="search">Search</string>
     <string name="error">An error has occurred</string>


### PR DESCRIPTION
（Note: This modification of the app name is entirely for the convenience of distinguishing between the Skyline app and the mounted path during development）