### PR TITLE
Implement info reading from Ro section

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -397,4 +397,4 @@ target_include_directories(skyline PRIVATE ${source_DIR}/skyline)
 target_compile_options(skyline PRIVATE -Wall -Wno-unknown-attributes -Wno-c++20-extensions -Wno-c++17-extensions -Wno-c99-designator -Wno-reorder -Wno-missing-braces -Wno-unused-variable -Wno-unused-private-field -Wno-dangling-else -Wconversion -fsigned-bitfields)
 
 target_link_libraries(skyline PRIVATE shader_recompiler audio_core)
-target_link_libraries_system(skyline android perfetto fmt lz4_static tzcode vkma mbedcrypto opus Boost::intrusive Boost::container Boost::preprocessor range-v3 adrenotools tsl::robin_map)
+target_link_libraries_system(skyline android perfetto fmt lz4_static tzcode vkma mbedcrypto opus Boost::intrusive Boost::container Boost::preprocessor Boost::regex range-v3 adrenotools tsl::robin_map)

--- a/app/src/main/cpp/skyline/loader/nso.h
+++ b/app/src/main/cpp/skyline/loader/nso.h
@@ -89,6 +89,8 @@ namespace skyline::loader {
          */
         static ExecutableLoadInfo LoadNso(Loader *loader, const std::shared_ptr<vfs::Backing> &backing, const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state, size_t offset = 0, const std::string &name = {}, bool dynamicallyLinked = false);
 
+        static void PrintRoContentsInfo(const std::vector<u8> &contents);
+
         void *LoadProcessData(const std::shared_ptr<kernel::type::KProcess> &process, const DeviceState &state) override;
     };
 }


### PR DESCRIPTION
It's not very important, but pretty cool for my opinion. I decided to push it right now because it's not related to vfs.

It will print something like:
```
PrintRoContentsInfo: Module Path: E:\Repositories\cuphead-nintendo-switch\SwitchIL2CPPCache\il2cpp_cache\linkresult_323CF82D553118E0341B6EB63686C231\SwitchPlayer.nss
PrintRoContentsInfo: SDK Libraries: SDK MW+UnityTechnologies+Unity-2017_4_9_f1
                 SDK MW+Nintendo+NintendoSDK_libcurl-5_5_0-Release
LoadExeFs: Loaded 'main.nso' at 0x800005000 (.text @ 0x800006000)
PrintRoContentsInfo: Module Path: multimedia
PrintRoContentsInfo: SDK Libraries: SDK MW+Nintendo+NintendoSDK_movie-5_5_0-Release
LoadExeFs: Loaded 'subsdk0.nso' at 0x803b3d000 (.text @ 0x803b3e000)
PrintRoContentsInfo: Module Path: nnSdk
PrintRoContentsInfo: SDK Version: 5.5.0
PrintRoContentsInfo: SDK Libraries: SDK MW+Nintendo+NintendoSDK_libz-5_5_0-Release
                 SDK MW+Nintendo+NintendoSdk_nnSdk-5_5_0-Release
                 SDK MW+Nintendo+NintendoSDK_NVN-5_5_0-Release
```
It might help for some specific cases and for creating compatibility list.

Thanks Ryujinx for the idea!