### PR TITLE
Simplify signal handling and remove per-thread handlers

### DIFF
--- a/app/src/main/cpp/emu_jni.cpp
+++ b/app/src/main/cpp/emu_jni.cpp
@@ -94,6 +94,8 @@ extern "C" JNIEXPORT void Java_emu_skyline_EmulationActivity_executeApplication(
         skyline::JniString nativeLibraryPath(env, nativeLibraryPathJstring);
         skyline::JniString privateAppFilesPath{env, privateAppFilesPathJstring};
 
+        // Host signal handlers need to be set before NCE is initialized, this is the only place where we can do that
+        skyline::signal::SetHostSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, skyline::signal::ExceptionalSignalHandler);
         auto os{std::make_shared<skyline::kernel::OS>(
             jvmManager,
             settings,

--- a/app/src/main/cpp/skyline/gpu/command_scheduler.cpp
+++ b/app/src/main/cpp/skyline/gpu/command_scheduler.cpp
@@ -14,8 +14,6 @@ namespace skyline::gpu {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
-
             cycleQueue.Process([](const std::shared_ptr<FenceCycle> &cycle) {
                 cycle->Wait(true);
             }, [] {});

--- a/app/src/main/cpp/skyline/gpu/command_scheduler.h
+++ b/app/src/main/cpp/skyline/gpu/command_scheduler.h
@@ -43,9 +43,9 @@ namespace skyline::gpu {
         };
         ThreadLocal<CommandPool> pool;
 
-        std::thread waiterThread; //!< A thread that waits on and signals FenceCycle(s) then clears any associated resources
         static constexpr size_t FenceCycleWaitCount{256}; //!< The amount of fence cycles the cycle queue can hold
         CircularQueue<std::shared_ptr<FenceCycle>> cycleQueue{FenceCycleWaitCount}; //!< A circular queue containing all the active cycles that can be waited on
+        std::thread waiterThread; //!< A thread that waits on and signals FenceCycle(s) then clears any associated resources
 
         void WaiterThread();
 

--- a/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
+++ b/app/src/main/cpp/skyline/gpu/interconnect/command_executor.cpp
@@ -188,8 +188,6 @@ namespace skyline::gpu::interconnect {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
-
             incoming.Process([this, renderDocApi, &gpu](Slot *slot) {
                 idle = false;
                 VkInstance instance{*gpu.vkInstance};
@@ -244,8 +242,6 @@ namespace skyline::gpu::interconnect {
     }
 
     void ExecutionWaiterThread::Run() {
-        signal::SetSignalHandler({SIGSEGV}, nce::NCE::HostSignalHandler); // We may access NCE trapped memory
-
         // Enable turbo clocks to begin with if requested
         if (*state.settings->forceMaxGpuClocks)
             adrenotools_set_turbo(true);

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.cpp
@@ -74,7 +74,6 @@ namespace skyline::gpu {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
             choreographerLooper = ALooper_prepare(0);
             AChoreographer_postFrameCallback64(AChoreographer_getInstance(), reinterpret_cast<AChoreographer_frameCallback64>(&ChoreographerCallback), this);
             while (ALooper_pollAll(-1, nullptr, nullptr, nullptr) == ALOOPER_POLL_WAKE && !choreographerStop); // Will block and process callbacks till ALooper_wake() is called with choreographerStop set
@@ -235,8 +234,6 @@ namespace skyline::gpu {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
-
             presentQueue.Process([this](const PresentableFrame &frame) {
                 PresentFrame(frame);
                 frame.presentCallback(); // We're calling the callback here as it's outside of all the locks in PresentFrame

--- a/app/src/main/cpp/skyline/gpu/presentation_engine.h
+++ b/app/src/main/cpp/skyline/gpu/presentation_engine.h
@@ -56,11 +56,11 @@ namespace skyline::gpu {
         std::shared_ptr<kernel::type::KEvent> vsyncEvent; //!< Signalled every time a frame is drawn
 
       private:
-        std::thread choreographerThread; //!< A thread for signalling the V-Sync event and measure the refresh cycle duration using AChoreographer
         ALooper *choreographerLooper{};
         i64 lastChoreographerTime{}; //!< The timestamp of the last invocation of Choreographer::doFrame
         i64 refreshCycleDuration{}; //!< The duration of a single refresh cycle for the display in nanoseconds
         bool choreographerStop{}; //!< If the Choreographer thread should stop on the next ALooper_wake()
+        std::thread choreographerThread; //!< A thread for signalling the V-Sync event and measure the refresh cycle duration using AChoreographer
 
         struct PresentableFrame {
             std::shared_ptr<TextureView> textureView{};
@@ -75,9 +75,9 @@ namespace skyline::gpu {
             service::hosbinder::NativeWindowTransform transform{};
         };
 
-        std::thread presentationThread; //!< A thread for asynchronously presenting queued frames after their corresponded fences are signalled
         static constexpr size_t PresentQueueFrameCount{5}; //!< The amount of frames the presentation queue can hold
         CircularQueue<PresentableFrame> presentQueue{PresentQueueFrameCount}; //!< A circular queue containing all the frames that we can present
+        std::thread presentationThread; //!< A thread for asynchronously presenting queued frames after their corresponded fences are signalled
         size_t nextFrameId{1}; //!< The frame ID to use for the next frame
 
         /**

--- a/app/src/main/cpp/skyline/input.cpp
+++ b/app/src/main/cpp/skyline/input.cpp
@@ -21,8 +21,6 @@ namespace skyline::input {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, signal::ExceptionalSignalHandler);
-
             struct UpdateCallback {
                 std::chrono::milliseconds period;
                 std::chrono::steady_clock::time_point next;

--- a/app/src/main/cpp/skyline/kernel/scheduler.h
+++ b/app/src/main/cpp/skyline/kernel/scheduler.h
@@ -72,8 +72,8 @@ namespace skyline {
 
           public:
             static constexpr std::chrono::milliseconds PreemptiveTimeslice{10}; //!< The duration of time a preemptive thread can run before yielding
-            inline static int YieldSignal{SIGRTMIN}; //!< The signal used to cause a non-cooperative yield in running threads
-            inline static int PreemptionSignal{SIGRTMIN + 1}; //!< The signal used to cause a preemptive yield in running threads
+            inline static int YieldSignal{SIGRTMIN}; //!< The signal used to cause a non-cooperative yield in running threads (41)
+            inline static int PreemptionSignal{SIGRTMIN + 1}; //!< The signal used to cause a preemptive yield in running threads (42)
             inline static thread_local bool YieldPending{}; //!< A flag denoting if a yield is pending on this thread, it's checked prior to entering guest code as signals cannot interrupt host code
 
             Scheduler(const DeviceState &state);
@@ -81,7 +81,12 @@ namespace skyline {
             /**
              * @brief A signal handler designed to cause a non-cooperative yield for preemption and higher priority threads being inserted
              */
-            static void SignalHandler(int signal, siginfo *info, ucontext *ctx, void **tls);
+            static void GuestSignalHandler(int signal, siginfo *info, ucontext *ctx, void **tls);
+
+            /**
+             * @brief A signal handler for scheduling guest threads not currently running guest code
+             */
+            static void HostSignalHandler(int signal, siginfo *info, ucontext *ctx);
 
             /**
              * @brief Checks all cores and determines the core where the supplied thread should be scheduled the earliest

--- a/app/src/main/cpp/skyline/kernel/types/KThread.cpp
+++ b/app/src/main/cpp/skyline/kernel/types/KThread.cpp
@@ -80,9 +80,6 @@ namespace skyline::kernel::type {
         if (timer_create(CLOCK_THREAD_CPUTIME_ID, &event, &preemptionTimer))
             throw exception("timer_create has failed with '{}'", strerror(errno));
 
-        signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE, SIGSEGV}, nce::NCE::SignalHandler);
-        signal::SetSignalHandler({Scheduler::YieldSignal, Scheduler::PreemptionSignal}, Scheduler::SignalHandler, false); // We want futexes to fail and their predicates rechecked
-
         {
             std::scoped_lock lock{statusMutex};
             ready = true;

--- a/app/src/main/cpp/skyline/soc/gm20b/gpfifo.cpp
+++ b/app/src/main/cpp/skyline/soc/gm20b/gpfifo.cpp
@@ -373,9 +373,6 @@ namespace skyline::soc::gm20b {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE}, signal::ExceptionalSignalHandler);
-            signal::SetSignalHandler({SIGSEGV}, nce::NCE::HostSignalHandler); // We may access NCE trapped memory
-
             bool channelLocked{};
 
             gpEntries.Process([this, &channelLocked](GpEntry gpEntry) {

--- a/app/src/main/cpp/skyline/soc/host1x/command_fifo.cpp
+++ b/app/src/main/cpp/skyline/soc/host1x/command_fifo.cpp
@@ -119,9 +119,6 @@ namespace skyline::soc::host1x {
         AsyncLogger::UpdateTag();
 
         try {
-            signal::SetSignalHandler({SIGINT, SIGILL, SIGTRAP, SIGBUS, SIGFPE}, signal::ExceptionalSignalHandler);
-            signal::SetSignalHandler({SIGSEGV}, nce::NCE::HostSignalHandler); // We may access NCE trapped memory
-
             gatherQueue.Process([this](span<u32> gather) {
                 LOGD("Processing pushbuffer: {}, size: 0x{:X}", fmt::ptr(gather.data()), gather.size());
                 Process(gather);


### PR DESCRIPTION
This PR fixes crashes occurring on most devices after updating to the August 2023 security patches. The crashes were caused by incorrect signal dispatch of our `ThreadSignalHandler`.

See commit description for details.