### PR TITLE
Used dstPosition

### DIFF
--- a/app/src/main/shaders/blit.vert
+++ b/app/src/main/shaders/blit.vert
@@ -8,7 +8,7 @@ layout (push_constant) uniform constants {
 } PC;
 
 void main() {
-	const vec2 lut[6] = vec2[6](
+    const vec2 lut[6] = vec2[6](
         vec2(0, 0),
         vec2(0, 1),
         vec2(1, 1),
@@ -18,5 +18,5 @@ void main() {
     );
 
     dstPosition = lut[gl_VertexIndex];
-    gl_Position = vec4(PC.dstOriginClipSpace + PC.dstDimensionsClipSpace * lut[gl_VertexIndex], 0, 1);
+    gl_Position = vec4(PC.dstOriginClipSpace + PC.dstDimensionsClipSpace * dstPosition, 0, 1);
 }


### PR DESCRIPTION
Removed the redundant lookup in gl_Position and used dstPosition directly for a cleaner and more readable code.