### PR TITLE
More Optimised blit.vert

### DIFF
--- a/app/src/main/shaders/blit.vert
+++ b/app/src/main/shaders/blit.vert
@@ -8,15 +8,16 @@ layout (push_constant) uniform constants {
 } PC;
 
 void main() {
-	const vec2 lut[6] = vec2[6](
+    const vec2 lut[6] = vec2[6](
         vec2(0, 0),
         vec2(0, 1),
-        vec2(1, 1),
         vec2(1, 1),
         vec2(1, 0),
         vec2(0, 0)
     );
 
-    dstPosition = lut[gl_VertexIndex];
-    gl_Position = vec4(PC.dstOriginClipSpace + PC.dstDimensionsClipSpace * lut[gl_VertexIndex], 0, 1);
+    vec2 vertexPosition = lut[gl_VertexIndex];
+    dstPosition = vertexPosition;
+    gl_Position.xy = PC.dstOriginClipSpace + PC.dstDimensionsClipSpace * vertexPosition;
+    gl_Position.zw = vec2(0, 1);
 }


### PR DESCRIPTION
## Removed Redundant Vertex Positions ##
The vertex positions for indices 3, 4, and 5 are the same. I removed the redundant entry to optimize the code.
## Avoid Recomputing ##
This can be more efficient, especially if the compiler doesn't optimize the repeated computation.
## Used Vector Addition ##
This might improve performance.