### PR TITLE
Add explicit toString to exceptions in Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,7 +208,7 @@ def getGitVersionName() {
         if (!isTag)
             versionName += '-' + getGitBranch() + '-' + getGitShortHash()
     } catch (Exception e) {
-        logger.quiet(e + ': defaulting to dummy version number ' + versionName)
+        logger.quiet(e.toString() + ': defaulting to dummy version number ' + versionName)
     }
 
     logger.quiet('Version name: ' + versionName)
@@ -225,7 +225,7 @@ def getGitVersionCode() {
         versionCode = Integer.max('git rev-list --first-parent --count --tags'.execute([], project.rootDir).text
                 .toInteger(), versionCode)
     } catch (Exception e) {
-        logger.error(e + ': defaulting to dummy version code ' + versionCode)
+        logger.error(e.toString() + ': defaulting to dummy version code ' + versionCode)
     }
 
     logger.quiet('Version code: ' + versionCode)
@@ -241,7 +241,7 @@ def getGitShortHash() {
     try {
         gitHash = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
     } catch (Exception e) {
-        logger.error(e + ': defaulting to dummy build hash ' + gitHash)
+        logger.error(e.toString() + ': defaulting to dummy build hash ' + gitHash)
     }
 
     return gitHash
@@ -256,7 +256,7 @@ def getGitBranch() {
     try {
         branch = 'git rev-parse --abbrev-ref HEAD'.execute([], project.rootDir).text.trim()
     } catch (Exception e) {
-        logger.error(e + ': defaulting to dummy branch ' + branch)
+        logger.error(e.toString() + ': defaulting to dummy branch ' + branch)
     }
 
     return branch


### PR DESCRIPTION
Groovy overloads the `+` operator with `plus()`. 

When concatenating the exception with a string you might be invoking something like `e.plus('text')`. The exception class does not override the `plus()` so that would produce an error.

By changing `e` to `e.toString()`, it is ensured that a string is on the left side of the + operator, and thus the `plus()` method is being called on a string.