### PR TITLE
Fix invalid switch-case syntax resulting from `nvdrv` macro expansion

### DIFF
--- a/app/src/main/cpp/skyline/services/nvdrv/devices/deserialisation/macro_def.inc
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/deserialisation/macro_def.inc
@@ -7,7 +7,7 @@
     PosixResult name::type(IoctlDescriptor cmd, span<u8> buffer, span<u8> inlineBuffer) {   \
         using className = name;                                                             \
         switch (cmd.raw) {                                                                  \
-            cases;                                                                          \
+            cases                                                                           \
             default:                                                                        \
                 return PosixResult::InappropriateIoctlForDevice;                            \
         }                                                                                   \
@@ -17,11 +17,11 @@
     PosixResult name::Ioctl(IoctlDescriptor cmd, span<u8> buffer) {      \
         using className = name;                                          \
         switch (cmd.raw) {                                               \
-            cases;                                                       \
+            cases                                                        \
             default:                                                     \
                 cmd.size = 0;                                            \
                 switch (cmd.raw) {                                       \
-                    variableCases;                                       \
+                    variableCases                                        \
                     default:                                             \
                         return PosixResult::InappropriateIoctlForDevice; \
                 }                                                        \
@@ -32,7 +32,7 @@
     PosixResult name::Ioctl(IoctlDescriptor cmd, span<u8> buffer) { \
         using className = name;                                     \
         switch (cmd.raw) {                                          \
-            cases;                                                  \
+            cases                                                   \
             default:                                                \
                 return PosixResult::InappropriateIoctlForDevice;    \
         }                                                           \

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/as_gpu.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/as_gpu.cpp
@@ -354,10 +354,11 @@ namespace skyline::service::nvdrv::device::nvhost {
         return PosixResult::Success;
     }
 
+// @fmt:off
 #include <services/nvdrv/devices/deserialisation/macro_def.inc>
     static constexpr u32 AsGpuMagic{0x41};
 
-    VARIABLE_IOCTL_HANDLER_FUNC(AsGpu, ({
+    VARIABLE_IOCTL_HANDLER_FUNC(AsGpu,
         IOCTL_CASE_ARGS(IN,    SIZE(0x4),  MAGIC(AsGpuMagic), FUNC(0x1),
                         BindChannel,  ARGS(In<FileDescriptor>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x18), MAGIC(AsGpuMagic), FUNC(0x2),
@@ -372,14 +373,15 @@ namespace skyline::service::nvdrv::device::nvhost {
                         GetVaRegions, ARGS(In<u64>, InOut<u32>, Pad<u32>, Out<std::array<VaRegion, 2>>))
         IOCTL_CASE_ARGS(IN,    SIZE(0x28), MAGIC(AsGpuMagic), FUNC(0x9),
                         AllocAsEx,    ARGS(In<u32>, In<FileDescriptor>, In<u32>, Pad<u32>, In<u64>, In<u64>, In<u64>))
-    }), ({
+    ,
         VARIABLE_IOCTL_CASE_ARGS(INOUT, MAGIC(AsGpuMagic), FUNC(0x14),
                                  Remap, ARGS(AutoSizeSpan<RemapEntry>))
-    }))
+    )
 
-    INLINE_IOCTL_HANDLER_FUNC(Ioctl3, AsGpu, ({
+    INLINE_IOCTL_HANDLER_FUNC(Ioctl3, AsGpu,
         INLINE_IOCTL_CASE_ARGS(INOUT, SIZE(0x40), MAGIC(AsGpuMagic), FUNC(0x8),
                                GetVaRegions3, ARGS(In<u64>, InOut<u32>, Pad<u32>, Out<std::array<VaRegion, 2>>))
-    }))
+    )
 #include <services/nvdrv/devices/deserialisation/macro_undef.inc>
+// @fmt:on
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl.cpp
@@ -249,10 +249,11 @@ namespace skyline::service::nvdrv::device::nvhost {
         return nullptr;
     }
 
+// @fmt:off
 #include <services/nvdrv/devices/deserialisation/macro_def.inc>
     static constexpr u32 CtrlMagic{0};
 
-    IOCTL_HANDLER_FUNC(Ctrl, ({
+    IOCTL_HANDLER_FUNC(Ctrl,
         IOCTL_CASE_ARGS(INOUT, SIZE(0x4),  MAGIC(CtrlMagic), FUNC(0x1C),
                         SyncpointClearEventWait,  ARGS(In<SyncpointEventValue>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x10), MAGIC(CtrlMagic), FUNC(0x1D),
@@ -268,6 +269,7 @@ namespace skyline::service::nvdrv::device::nvhost {
 
         IOCTL_CASE_RESULT(INOUT, SIZE(0x183), MAGIC(CtrlMagic), FUNC(0x1B),
                           PosixResult::InvalidArgument) // GetConfig isn't available in production
-    }))
+    )
 #include <services/nvdrv/devices/deserialisation/macro_undef.inc>
+// @fmt:on
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl_gpu.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl_gpu.cpp
@@ -72,10 +72,11 @@ namespace skyline::service::nvdrv::device::nvhost {
         }
     }
 
+// @fmt:off
 #include <services/nvdrv/devices/deserialisation/macro_def.inc>
     static constexpr u32 CtrlGpuMagic{0x47};
 
-    IOCTL_HANDLER_FUNC(CtrlGpu, ({
+    IOCTL_HANDLER_FUNC(CtrlGpu,
         IOCTL_CASE_ARGS(OUT,   SIZE(0x4),  MAGIC(CtrlGpuMagic), FUNC(0x1),
                         ZCullGetCtxSize,    ARGS(Out<u32>))
         IOCTL_CASE_ARGS(OUT,   SIZE(0x28), MAGIC(CtrlGpuMagic), FUNC(0x2),
@@ -90,13 +91,14 @@ namespace skyline::service::nvdrv::device::nvhost {
                         GetActiveSlotMask,  ARGS(Out<u32>, Out<u32>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x10), MAGIC(CtrlGpuMagic), FUNC(0x1C),
                         GetGpuTime,         ARGS(Out<u64>, Pad<u64>))
-    }))
+    )
 
-    INLINE_IOCTL_HANDLER_FUNC(Ioctl3, CtrlGpu, ({
+    INLINE_IOCTL_HANDLER_FUNC(Ioctl3, CtrlGpu,
         INLINE_IOCTL_CASE_ARGS(INOUT, SIZE(0xB0), MAGIC(CtrlGpuMagic), FUNC(0x5),
                                GetCharacteristics3, ARGS(InOut<u64>, In<u64>, Out<GpuCharacteristics>))
         INLINE_IOCTL_CASE_ARGS(INOUT, SIZE(0x18), MAGIC(CtrlGpuMagic), FUNC(0x6),
                                GetTpcMasks3,        ARGS(In<u32>, Pad<u32, 3>, Out<u32>))
-    }))
+    )
 #include <services/nvdrv/devices/deserialisation/macro_undef.inc>
+// @fmt:on
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/gpu_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/gpu_channel.cpp
@@ -225,11 +225,12 @@ namespace skyline::service::nvdrv::device::nvhost {
         }
     }
 
+// @fmt:off
 #include <services/nvdrv/devices/deserialisation/macro_def.inc>
     static constexpr u32 GpuChannelUserMagic{0x47};
     static constexpr u32 GpuChannelMagic{0x48};
 
-    VARIABLE_IOCTL_HANDLER_FUNC(GpuChannel, ({
+    VARIABLE_IOCTL_HANDLER_FUNC(GpuChannel,
         IOCTL_CASE_ARGS(IN,    SIZE(0x4),  MAGIC(GpuChannelMagic),     FUNC(0x1),
                         SetNvmapFd,       ARGS(In<FileDescriptor>))
         IOCTL_CASE_ARGS(IN,    SIZE(0x4),  MAGIC(GpuChannelMagic),     FUNC(0x3),
@@ -250,14 +251,15 @@ namespace skyline::service::nvdrv::device::nvhost {
                         SetUserData,      ARGS(In<u64>))
         IOCTL_CASE_ARGS(OUT,   SIZE(0x8),  MAGIC(GpuChannelUserMagic), FUNC(0x15),
                         GetUserData,      ARGS(Out<u64>))
-    }), ({
+    ,
         VARIABLE_IOCTL_CASE_ARGS(INOUT, MAGIC(GpuChannelMagic), FUNC(0x8),
                                  SubmitGpfifo, ARGS(In<u64>, In<u32>, InOut<SubmitGpfifoFlags>, InOut<Fence>, AutoSizeSpan<soc::gm20b::GpEntry>))
-    }))
+    )
 
-    INLINE_IOCTL_HANDLER_FUNC(Ioctl2, GpuChannel, ({
+    INLINE_IOCTL_HANDLER_FUNC(Ioctl2, GpuChannel,
         INLINE_IOCTL_CASE_ARGS(INOUT, SIZE(0x18), MAGIC(GpuChannelMagic), FUNC(0x1B),
                                SubmitGpfifo2, ARGS(In<u64>, In<u32>, InOut<SubmitGpfifoFlags>, InOut<Fence>))
-    }))
+    )
 #include <services/nvdrv/devices/deserialisation/macro_undef.inc>
+// @fmt:on
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/host1x_channel.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/host1x_channel.cpp
@@ -111,11 +111,13 @@ namespace skyline::service::nvdrv::device::nvhost {
 
         return PosixResult::Success;
     }
+
+// @fmt:off
 #include <services/nvdrv/devices/deserialisation/macro_def.inc>
     static constexpr u32 Host1xChannelMagic{0x00};
     static constexpr u32 GpuChannelMagic{0x48}; //!< Used for SetNvmapFd which is needed in both GPU and host1x channels
 
-    VARIABLE_IOCTL_HANDLER_FUNC(Host1xChannel, ({
+    VARIABLE_IOCTL_HANDLER_FUNC(Host1xChannel,
         IOCTL_CASE_ARGS(IN,    SIZE(0x4), MAGIC(GpuChannelMagic),    FUNC(0x1),
                         SetNvmapFd,       ARGS(In<FileDescriptor>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x8), MAGIC(Host1xChannelMagic), FUNC(0x2),
@@ -124,7 +126,7 @@ namespace skyline::service::nvdrv::device::nvhost {
                         GetWaitBase,      ARGS(In<core::ChannelType>, Out<u32>))
         IOCTL_CASE_ARGS(IN,    SIZE(0x4), MAGIC(Host1xChannelMagic), FUNC(0x7),
                         SetSubmitTimeout, ARGS(In<u32>))
-    }), ({
+    ,
         VARIABLE_IOCTL_CASE_ARGS(INOUT, MAGIC(Host1xChannelMagic), FUNC(0x1),
                                  Submit,      ARGS(Save<u32, 0>, Save<u32, 1>, Save<u32, 2>, Save<u32, 3>,
                                                    SlotSizeSpan<SubmitCmdBuf, 0>,
@@ -134,6 +136,7 @@ namespace skyline::service::nvdrv::device::nvhost {
                                  MapBuffer,   ARGS(Save<u32, 0>, Pad<u32>, In<u8>, Pad<u8, 3>, SlotSizeSpan<BufferHandle, 0>))
         VARIABLE_IOCTL_CASE_ARGS(INOUT, MAGIC(Host1xChannelMagic), FUNC(0xA),
                                  UnmapBuffer, ARGS(Save<u32, 0>, Pad<u32>, In<u8>, Pad<u8, 3>, SlotSizeSpan<BufferHandle, 0>))
-    }))
+    )
 #include <services/nvdrv/devices/deserialisation/macro_undef.inc>
+// @fmt:on
 }

--- a/app/src/main/cpp/skyline/services/nvdrv/devices/nvmap.cpp
+++ b/app/src/main/cpp/skyline/services/nvdrv/devices/nvmap.cpp
@@ -133,10 +133,11 @@ namespace skyline::service::nvdrv::device {
         return PosixResult::Success;
     }
 
+// @fmt:off
 #include "deserialisation/macro_def.inc"
     static constexpr u32 NvMapMagic{1};
 
-    IOCTL_HANDLER_FUNC(NvMap, ({
+    IOCTL_HANDLER_FUNC(NvMap,
         IOCTL_CASE_ARGS(INOUT, SIZE(0x8),  MAGIC(NvMapMagic), FUNC(0x1),
                         Create, ARGS(In<u32>, Out<NvMapCore::Handle::Id>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x8),  MAGIC(NvMapMagic), FUNC(0x3),
@@ -149,7 +150,8 @@ namespace skyline::service::nvdrv::device {
                         Param,  ARGS(In<NvMapCore::Handle::Id>, In<HandleParameterType>, Out<u32>))
         IOCTL_CASE_ARGS(INOUT, SIZE(0x8),  MAGIC(NvMapMagic), FUNC(0xE),
                         GetId,  ARGS(Out<NvMapCore::Handle::Id>, In<NvMapCore::Handle::Id>))
-    }))
+    )
 #include "deserialisation/macro_undef.inc"
+// @fmt:on
 }
 


### PR DESCRIPTION
Versions of Clang newer than the one included in the latest NDK (26.1.x) complain about `case` labels not being reachable when they're inside `({` `})`. I'm not sure why older versions didn't care about it.