### PR TITLE
Introduce a generic register context for SVCs

### DIFF
--- a/app/src/main/cpp/skyline/common/wregister.h
+++ b/app/src/main/cpp/skyline/common/wregister.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2023 Strato Team and Contributors (https://github.com/strato-emu/)
+
+#pragma once
+
+#include <common/base.h>
+
+namespace skyline {
+    struct WRegister {
+        u32 lower;
+        u32 upper;
+
+        constexpr operator u32() const {
+            return lower;
+        }
+
+        void operator=(u32 value) {
+            lower = value;
+            upper = 0;
+        }
+    };
+}

--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -1325,12 +1325,150 @@ namespace skyline::kernel::svc {
                 return;
         }
 
-        if (result == Result{})
-            [[likely]]
-                LOGD("Signalled {} for {} successfully", fmt::ptr(address), count);
+        if (result == Result{}) [[likely]]
+            LOGD("Signalled {} for {} successfully", fmt::ptr(address), count);
         else if (result == result::InvalidState)
             LOGD("The value at {} did not satisfy the mutation condition", fmt::ptr(address));
 
         ctx.w0 = result;
     }
+
+    #define SVC_NONE SvcDescriptor{} //!< A macro with a placeholder value for the SVC not being implemented or not existing
+    #define SVC_STRINGIFY(name) #name
+    #define SVC_ENTRY(function) SvcDescriptor{function, SVC_STRINGIFY(Svc ## function)} //!< A macro which automatically stringifies the function name as the name to prevent pointless duplication
+
+    constexpr std::array<SvcDescriptor, 0x80> SvcTable{
+        SVC_NONE, // 0x00 (Does not exist)
+        SVC_ENTRY(SetHeapSize), // 0x01
+        SVC_ENTRY(SetMemoryPermission), // 0x02
+        SVC_ENTRY(SetMemoryAttribute), // 0x03
+        SVC_ENTRY(MapMemory), // 0x04
+        SVC_ENTRY(UnmapMemory), // 0x05
+        SVC_ENTRY(QueryMemory), // 0x06
+        SVC_ENTRY(ExitProcess), // 0x07
+        SVC_ENTRY(CreateThread), // 0x08
+        SVC_ENTRY(StartThread), // 0x09
+        SVC_ENTRY(ExitThread), // 0x0A
+        SVC_ENTRY(SleepThread), // 0x0B
+        SVC_ENTRY(GetThreadPriority), // 0x0C
+        SVC_ENTRY(SetThreadPriority), // 0x0D
+        SVC_ENTRY(GetThreadCoreMask), // 0x0E
+        SVC_ENTRY(SetThreadCoreMask), // 0x0F
+        SVC_ENTRY(GetCurrentProcessorNumber), // 0x10
+        SVC_NONE, // 0x11
+        SVC_ENTRY(ClearEvent), // 0x12
+        SVC_ENTRY(MapSharedMemory), // 0x13
+        SVC_ENTRY(UnmapSharedMemory), // 0x14
+        SVC_ENTRY(CreateTransferMemory), // 0x15
+        SVC_ENTRY(CloseHandle), // 0x16
+        SVC_ENTRY(ResetSignal), // 0x17
+        SVC_ENTRY(WaitSynchronization), // 0x18
+        SVC_ENTRY(CancelSynchronization), // 0x19
+        SVC_ENTRY(ArbitrateLock), // 0x1A
+        SVC_ENTRY(ArbitrateUnlock), // 0x1B
+        SVC_ENTRY(WaitProcessWideKeyAtomic), // 0x1C
+        SVC_ENTRY(SignalProcessWideKey), // 0x1D
+        SVC_ENTRY(GetSystemTick), // 0x1E
+        SVC_ENTRY(ConnectToNamedPort), // 0x1F
+        SVC_NONE, // 0x20
+        SVC_ENTRY(SendSyncRequest), // 0x21
+        SVC_NONE, // 0x22
+        SVC_NONE, // 0x23
+        SVC_NONE, // 0x24
+        SVC_ENTRY(GetThreadId), // 0x25
+        SVC_ENTRY(Break), // 0x26
+        SVC_ENTRY(OutputDebugString), // 0x27
+        SVC_NONE, // 0x28
+        SVC_ENTRY(GetInfo), // 0x29
+        SVC_NONE, // 0x2A
+        SVC_NONE, // 0x2B
+        SVC_ENTRY(MapPhysicalMemory), // 0x2C
+        SVC_ENTRY(UnmapPhysicalMemory), // 0x2D
+        SVC_NONE, // 0x2E
+        SVC_NONE, // 0x2F
+        SVC_NONE, // 0x30
+        SVC_NONE, // 0x31
+        SVC_ENTRY(SetThreadActivity), // 0x32
+        SVC_ENTRY(GetThreadContext3), // 0x33
+        SVC_ENTRY(WaitForAddress), // 0x34
+        SVC_ENTRY(SignalToAddress), // 0x35
+        SVC_NONE, // 0x36
+        SVC_NONE, // 0x37
+        SVC_NONE, // 0x38
+        SVC_NONE, // 0x39
+        SVC_NONE, // 0x3A
+        SVC_NONE, // 0x3B
+        SVC_NONE, // 0x3C
+        SVC_NONE, // 0x3D
+        SVC_NONE, // 0x3E
+        SVC_NONE, // 0x3F
+        SVC_NONE, // 0x40
+        SVC_NONE, // 0x41
+        SVC_NONE, // 0x42
+        SVC_NONE, // 0x43
+        SVC_NONE, // 0x44
+        SVC_NONE, // 0x45
+        SVC_NONE, // 0x46
+        SVC_NONE, // 0x47
+        SVC_NONE, // 0x48
+        SVC_NONE, // 0x49
+        SVC_NONE, // 0x4A
+        SVC_NONE, // 0x4B
+        SVC_NONE, // 0x4C
+        SVC_NONE, // 0x4D
+        SVC_NONE, // 0x4E
+        SVC_NONE, // 0x4F
+        SVC_NONE, // 0x50
+        SVC_NONE, // 0x51
+        SVC_NONE, // 0x52
+        SVC_NONE, // 0x53
+        SVC_NONE, // 0x54
+        SVC_NONE, // 0x55
+        SVC_NONE, // 0x56
+        SVC_NONE, // 0x57
+        SVC_NONE, // 0x58
+        SVC_NONE, // 0x59
+        SVC_NONE, // 0x5A
+        SVC_NONE, // 0x5B
+        SVC_NONE, // 0x5C
+        SVC_NONE, // 0x5D
+        SVC_NONE, // 0x5E
+        SVC_NONE, // 0x5F
+        SVC_NONE, // 0x60
+        SVC_NONE, // 0x61
+        SVC_NONE, // 0x62
+        SVC_NONE, // 0x63
+        SVC_NONE, // 0x64
+        SVC_NONE, // 0x65
+        SVC_NONE, // 0x66
+        SVC_NONE, // 0x67
+        SVC_NONE, // 0x68
+        SVC_NONE, // 0x69
+        SVC_NONE, // 0x6A
+        SVC_NONE, // 0x6B
+        SVC_NONE, // 0x6C
+        SVC_NONE, // 0x6D
+        SVC_NONE, // 0x6E
+        SVC_NONE, // 0x6F
+        SVC_NONE, // 0x70
+        SVC_NONE, // 0x71
+        SVC_NONE, // 0x72
+        SVC_NONE, // 0x73
+        SVC_NONE, // 0x74
+        SVC_NONE, // 0x75
+        SVC_NONE, // 0x76
+        SVC_NONE, // 0x77
+        SVC_NONE, // 0x78
+        SVC_NONE, // 0x79
+        SVC_NONE, // 0x7A
+        SVC_NONE, // 0x7B
+        SVC_NONE, // 0x7C
+        SVC_NONE, // 0x7D
+        SVC_NONE, // 0x7E
+        SVC_NONE // 0x7F
+    };
+
+    #undef SVC_NONE
+    #undef SVC_STRINGIFY
+    #undef SVC_ENTRY
 }

--- a/app/src/main/cpp/skyline/kernel/svc.cpp
+++ b/app/src/main/cpp/skyline/kernel/svc.cpp
@@ -10,18 +10,18 @@
 #include "svc.h"
 
 namespace skyline::kernel::svc {
-    void SetHeapSize(const DeviceState &state) {
-        u32 size{state.ctx->gpr.w1};
+    void SetHeapSize(const DeviceState &state, SvcContext &ctx) {
+        u32 size{ctx.w1};
 
         if (!util::IsAligned(size, 0x200000)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
-            state.ctx->gpr.x1 = 0;
+            ctx.w0 = result::InvalidSize;
+            ctx.x1 = 0;
 
             LOGW("'size' not divisible by 2MB: 0x{:X}", size);
             return;
         } else if (state.process->memory.heap.size() < size) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
-            state.ctx->gpr.x1 = 0;
+            ctx.w0 = result::InvalidSize;
+            ctx.x1 = 0;
 
             LOGW("'size' exceeded size of heap region: 0x{:X}", size);
             return;
@@ -37,43 +37,43 @@ namespace skyline::kernel::svc {
 
         state.process->memory.processHeapSize = size;
 
-        state.ctx->gpr.w0 = Result{};
-        state.ctx->gpr.x1 = reinterpret_cast<u64>(heapBaseAddr);
+        ctx.w0 = Result{};
+        ctx.x1 = reinterpret_cast<u64>(heapBaseAddr);
 
         LOGD("Heap size changed to 0x{:X} bytes ({} - {})", size, fmt::ptr(heapBaseAddr), fmt::ptr(heapBaseAddr + size));
     }
 
-    void SetMemoryPermission(const DeviceState &state) {
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
+    void SetMemoryPermission(const DeviceState &state, SvcContext &ctx) {
+        u8 *address{reinterpret_cast<u8 *>(ctx.x0)};
         if (!util::IsPageAligned(address)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("'address' not page aligned: {}", fmt::ptr(address));
             return;
         }
 
-        u64 size{state.ctx->gpr.x1};
+        u64 size{ctx.x1};
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (address >= (address + size) || !state.process->memory.AddressSpaceContains(span<u8>{address, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+            ctx.w0 = result::InvalidCurrentMemory;
             LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X} ", fmt::ptr(address), size);
             return;
         }
 
-        memory::Permission newPermission(static_cast<u8>(state.ctx->gpr.w2));
+        memory::Permission newPermission(static_cast<u8>(ctx.w2));
         if ((!newPermission.r && newPermission.w) || newPermission.x) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidNewMemoryPermission;
+            ctx.w0 = result::InvalidNewMemoryPermission;
             LOGW("'permission' invalid: {}", newPermission);
             return;
         }
 
         auto chunk{state.process->memory.GetChunk(address).value()};
         if (!chunk.second.state.permissionChangeAllowed) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidState;
+            ctx.w0 = result::InvalidState;
             LOGW("Permission change not allowed for chunk at: {}, state: 0x{:X}", chunk.first, chunk.second.state.value);
             return;
         }
@@ -81,36 +81,36 @@ namespace skyline::kernel::svc {
         state.process->memory.SetRegionPermission(span<u8>(address, size), newPermission);
 
         LOGD("Set permission to {}{}{} at {} - {} (0x{:X} bytes)", newPermission.r ? 'R' : '-', newPermission.w ? 'W' : '-', newPermission.x ? 'X' : '-', fmt::ptr(address), fmt::ptr(address + size), size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void SetMemoryAttribute(const DeviceState &state) {
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
+    void SetMemoryAttribute(const DeviceState &state, SvcContext &ctx) {
+        u8 *address{reinterpret_cast<u8 *>(ctx.x0)};
         if (!util::IsPageAligned(address)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("'address' not page aligned: {}", fmt::ptr(address));
             return;
         }
 
-        u64 size{state.ctx->gpr.x1};
+        u64 size{ctx.x1};
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (address >= (address + size) || !state.process->memory.AddressSpaceContains(span<u8>{address, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+            ctx.w0 = result::InvalidCurrentMemory;
             LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X} ", fmt::ptr(address), size);
             return;
         }
 
-        memory::MemoryAttribute mask{static_cast<u8>(state.ctx->gpr.w2)};
-        memory::MemoryAttribute value{static_cast<u8>(state.ctx->gpr.w3)};
+        memory::MemoryAttribute mask{static_cast<u8>(ctx.w2)};
+        memory::MemoryAttribute value{static_cast<u8>(ctx.w3)};
 
         auto maskedValue{mask.value | value.value};
         if (maskedValue != mask.value || !mask.isUncached || mask.isDeviceShared || mask.isBorrowed || mask.isIpcLocked) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCombination;
+            ctx.w0 = result::InvalidCombination;
             LOGW("'mask' invalid: 0x{:X}, 0x{:X}", mask.value, value.value);
             return;
         }
@@ -119,7 +119,7 @@ namespace skyline::kernel::svc {
 
         // We only check the first found chunk for whatever reason.
         if (!chunk.second.state.attributeChangeAllowed) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidState;
+            ctx.w0 = result::InvalidState;
             LOGW("Attribute change not allowed for chunk: {}", fmt::ptr(chunk.first));
             return;
         }
@@ -127,47 +127,47 @@ namespace skyline::kernel::svc {
         state.process->memory.SetRegionCpuCaching(span<u8>{address, size}, value.isUncached);
 
         LOGD("Set CPU caching to {} at {} - {} (0x{:X} bytes)", static_cast<bool>(value.isUncached), fmt::ptr(address), fmt::ptr(address + size), size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void MapMemory(const DeviceState &state) {
-        u8 *destination{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
-        u8 *source{reinterpret_cast<u8 *>(state.ctx->gpr.x1)};
-        size_t size{state.ctx->gpr.x2};
+    void MapMemory(const DeviceState &state, SvcContext &ctx) {
+        u8 *destination{reinterpret_cast<u8 *>(ctx.x0)};
+        u8 *source{reinterpret_cast<u8 *>(ctx.x1)};
+        size_t size{ctx.x2};
 
         if (!util::IsPageAligned(destination) || !util::IsPageAligned(source)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("Addresses not page aligned: 'source': {}, 'destination': {}, 'size': 0x{:X} bytes", fmt::ptr(source), fmt::ptr(destination), size);
             return;
         }
 
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (destination >= (destination + size) || !state.process->memory.AddressSpaceContains(span<u8>{destination, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+            ctx.w0 = result::InvalidCurrentMemory;
             LOGW("Invalid address and size combination: 'destination': {}, 'size': 0x{:X} bytes", fmt::ptr(destination), size);
             return;
         }
 
         if (source >= (source + size) || !state.process->memory.AddressSpaceContains(span<u8>{source, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+            ctx.w0 = result::InvalidCurrentMemory;
             LOGW("Invalid address and size combination: 'source': {}, 'size': 0x{:X} bytes", fmt::ptr(source), size);
             return;
         }
 
         if (!state.process->memory.stack.guest.contains(span<u8>{destination, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidMemoryRegion;
+            ctx.w0 = result::InvalidMemoryRegion;
             LOGW("Destination not within stack region: 'source': {}, 'destination': {}, 'size': 0x{:X} bytes", fmt::ptr(source), fmt::ptr(destination), size);
             return;
         }
 
         auto chunk{state.process->memory.GetChunk(source)};
         if (!chunk->second.state.mapAllowed) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidState;
+            ctx.w0 = result::InvalidState;
             LOGW("Source doesn't allow usage of svcMapMemory: 'source': {}, 'size': {}, MemoryState: 0x{:X}", fmt::ptr(source), size, chunk->second.state.value);
             return;
         }
@@ -175,28 +175,28 @@ namespace skyline::kernel::svc {
         state.process->memory.SvcMapMemory(span<u8>{source, size}, span<u8>{destination, size});
 
         LOGD("Mapped range {} - {} to {} - {} (Size: 0x{:X} bytes)", fmt::ptr(source), fmt::ptr(source + size), fmt::ptr(destination), fmt::ptr(destination + size), size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void UnmapMemory(const DeviceState &state) {
-        u8 *destination{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
-        u8 *source{reinterpret_cast<u8 *>(state.ctx->gpr.x1)};
-        size_t size{state.ctx->gpr.x2};
+    void UnmapMemory(const DeviceState &state, SvcContext &ctx) {
+        u8 *destination{reinterpret_cast<u8 *>(ctx.x0)};
+        u8 *source{reinterpret_cast<u8 *>(ctx.x1)};
+        size_t size{ctx.x2};
 
         if (!util::IsPageAligned(destination) || !util::IsPageAligned(source)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("Addresses not page aligned: 'source': {}, 'destination': {}, 'size': {} bytes", fmt::ptr(source), fmt::ptr(destination), size);
             return;
         }
 
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (!state.process->memory.stack.guest.contains(span<u8>{destination, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidMemoryRegion;
+            ctx.w0 = result::InvalidMemoryRegion;
             LOGW("Source not within stack region: 'source': {}, 'destination': {}, 'size': 0x{:X} bytes", fmt::ptr(source), fmt::ptr(destination), size);
             return;
         }
@@ -205,13 +205,13 @@ namespace skyline::kernel::svc {
         state.process->memory.UnmapMemory(span<u8>{destination, size});
 
         LOGD("Unmapped range {} - {} to {} - {} (Size: 0x{:X} bytes)", fmt::ptr(destination), fmt::ptr(destination + size), source, source + size, size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void QueryMemory(const DeviceState &state) {
+    void QueryMemory(const DeviceState &state, SvcContext &ctx) {
         memory::MemoryInfo memInfo{};
 
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x2)};
+        u8 *address{reinterpret_cast<u8 *>(ctx.x2)};
         auto chunk{state.process->memory.GetChunk(address)};
 
         if (chunk) {
@@ -238,14 +238,14 @@ namespace skyline::kernel::svc {
             LOGD("Trying to query memory outside of the application's address space: {}", fmt::ptr(address));
         }
 
-        *reinterpret_cast<memory::MemoryInfo *>(state.ctx->gpr.x0) = memInfo;
+        *reinterpret_cast<memory::MemoryInfo *>(ctx.x0) = memInfo;
         // The page info, which is always 0
-        state.ctx->gpr.w1 = 0;
+        ctx.w1 = 0;
 
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void ExitProcess(const DeviceState &state) {
+    void ExitProcess(const DeviceState &state, SvcContext &ctx) {
         LOGD("Exiting process");
         throw nce::NCE::ExitException(true);
     }
@@ -254,22 +254,22 @@ namespace skyline::kernel::svc {
     constexpr i32 IdealCoreUseProcessValue{-2};
     constexpr i32 IdealCoreNoUpdate{-3};
 
-    void CreateThread(const DeviceState &state) {
-        auto entry{reinterpret_cast<void *>(state.ctx->gpr.x1)};
-        auto entryArgument{state.ctx->gpr.x2};
-        auto stackTop{reinterpret_cast<u8 *>(state.ctx->gpr.x3)};
-        auto priority{static_cast<i8>(state.ctx->gpr.w4)};
-        auto idealCore{static_cast<i32>(state.ctx->gpr.w5)};
+    void CreateThread(const DeviceState &state, SvcContext &ctx) {
+        auto entry{reinterpret_cast<void *>(ctx.x1)};
+        auto entryArgument{ctx.x2};
+        auto stackTop{reinterpret_cast<u8 *>(ctx.x3)};
+        auto priority{static_cast<i8>(ctx.w4)};
+        auto idealCore{static_cast<i32>(ctx.w5)};
 
         idealCore = (idealCore == IdealCoreUseProcessValue) ? static_cast<i32>(state.process->npdm.meta.idealCore) : idealCore;
         if (idealCore < 0 || idealCore >= constant::CoreCount) {
-            state.ctx->gpr.w0 = result::InvalidCoreId;
+            ctx.w0 = result::InvalidCoreId;
             LOGW("'idealCore' invalid: {}", idealCore);
             return;
         }
 
         if (!state.process->npdm.threadInfo.priority.Valid(priority)) {
-            state.ctx->gpr.w0 = result::InvalidPriority;
+            ctx.w0 = result::InvalidPriority;
             LOGW("'priority' invalid: {}", priority);
             return;
         }
@@ -278,39 +278,39 @@ namespace skyline::kernel::svc {
         if (thread) {
             LOGD("Created thread #{} with handle 0x{:X} (Entry Point: {}, Argument: 0x{:X}, Stack Pointer: {}, Priority: {}, Ideal Core: {})", thread->id, thread->handle, entry, entryArgument, fmt::ptr(stackTop), priority, idealCore);
 
-            state.ctx->gpr.w1 = thread->handle;
-            state.ctx->gpr.w0 = Result{};
+            ctx.w1 = thread->handle;
+            ctx.w0 = Result{};
         } else {
             LOGD("Cannot create thread (Entry Point: {}, Argument: 0x{:X}, Stack Pointer: {}, Priority: {}, Ideal Core: {})", entry, entryArgument, fmt::ptr(stackTop), priority, idealCore);
-            state.ctx->gpr.w1 = 0;
-            state.ctx->gpr.w0 = result::OutOfResource;
+            ctx.w1 = 0;
+            ctx.w0 = result::OutOfResource;
         }
     }
 
-    void StartThread(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w0};
+    void StartThread(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w0};
         try {
             auto thread{state.process->GetHandle<type::KThread>(handle)};
             LOGD("Starting thread #{}: 0x{:X}", thread->id, handle);
             thread->Start();
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void ExitThread(const DeviceState &state) {
+    void ExitThread(const DeviceState &state, SvcContext &ctx) {
         LOGD("Exiting current thread");
         throw nce::NCE::ExitException(false);
     }
 
-    void SleepThread(const DeviceState &state) {
+    void SleepThread(const DeviceState &state, SvcContext &ctx) {
         constexpr i64 yieldWithoutCoreMigration{0};
         constexpr i64 yieldWithCoreMigration{-1};
         constexpr i64 yieldToAnyThread{-2};
 
-        i64 in{static_cast<i64>(state.ctx->gpr.x0)};
+        i64 in{static_cast<i64>(ctx.x0)};
         if (in > 0) {
             LOGD("Sleeping for {}ns", in);
             TRACE_EVENT("kernel", "SleepThread", "duration", in);
@@ -355,27 +355,27 @@ namespace skyline::kernel::svc {
         }
     }
 
-    void GetThreadPriority(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w1};
+    void GetThreadPriority(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w1};
         try {
             auto thread{state.process->GetHandle<type::KThread>(handle)};
             i8 priority{thread->priority};
             LOGD("Retrieving thread #{}'s priority: {}", thread->id, priority);
 
-            state.ctx->gpr.w1 = static_cast<u32>(priority);
-            state.ctx->gpr.w0 = Result{};
+            ctx.w1 = static_cast<u32>(priority);
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void SetThreadPriority(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w0};
-        i8 priority{static_cast<i8>(state.ctx->gpr.w1)};
+    void SetThreadPriority(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w0};
+        i8 priority{static_cast<i8>(ctx.w1)};
         if (!state.process->npdm.threadInfo.priority.Valid(priority)) {
             LOGW("'priority' invalid: 0x{:X}", priority);
-            state.ctx->gpr.w0 = result::InvalidPriority;
+            ctx.w0 = result::InvalidPriority;
             return;
         }
         try {
@@ -393,34 +393,34 @@ namespace skyline::kernel::svc {
                 state.scheduler->UpdatePriority(thread);
                 thread->UpdatePriorityInheritance();
             }
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void GetThreadCoreMask(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w2};
+    void GetThreadCoreMask(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w2};
         try {
             auto thread{state.process->GetHandle<type::KThread>(handle)};
             auto idealCore{thread->idealCore};
             auto affinityMask{thread->affinityMask};
             LOGD("Getting thread #{}'s Ideal Core ({}) + Affinity Mask ({})", thread->id, idealCore, affinityMask);
 
-            state.ctx->gpr.x2 = affinityMask.to_ullong();
-            state.ctx->gpr.w1 = static_cast<u32>(idealCore);
-            state.ctx->gpr.w0 = Result{};
+            ctx.x2 = affinityMask.to_ullong();
+            ctx.w1 = static_cast<u32>(idealCore);
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void SetThreadCoreMask(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w0};
-        i32 idealCore{static_cast<i32>(state.ctx->gpr.w1)};
-        CoreMask affinityMask{state.ctx->gpr.x2};
+    void SetThreadCoreMask(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w0};
+        i32 idealCore{static_cast<i32>(ctx.w1)};
+        CoreMask affinityMask{ctx.x2};
         try {
             auto thread{state.process->GetHandle<type::KThread>(handle)};
 
@@ -436,13 +436,13 @@ namespace skyline::kernel::svc {
             auto processMask{state.process->npdm.threadInfo.coreMask};
             if ((processMask | affinityMask) != processMask) {
                 LOGW("'affinityMask' invalid: {} (Process Mask: {})", affinityMask, processMask);
-                state.ctx->gpr.w0 = result::InvalidCoreId;
+                ctx.w0 = result::InvalidCoreId;
                 return;
             }
 
             if (affinityMask.none() || !affinityMask.test(static_cast<size_t>(idealCore))) {
                 LOGW("'affinityMask' invalid: {} (Ideal Core: {})", affinityMask, idealCore);
-                state.ctx->gpr.w0 = result::InvalidCombination;
+                ctx.w0 = result::InvalidCombination;
                 return;
             }
 
@@ -467,62 +467,62 @@ namespace skyline::kernel::svc {
                 }
             }
 
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void GetCurrentProcessorNumber(const DeviceState &state) {
+    void GetCurrentProcessorNumber(const DeviceState &state, SvcContext &ctx) {
         std::scoped_lock guard{state.thread->coreMigrationMutex};
         u8 coreId{state.thread->coreId};
         LOGD("C{}", coreId);
-        state.ctx->gpr.w0 = coreId;
+        ctx.w0 = coreId;
     }
 
-    void ClearEvent(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w0};
+    void ClearEvent(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w0};
         TRACE_EVENT_FMT("kernel", "ClearEvent 0x{:X}", handle);
         try {
             std::static_pointer_cast<type::KEvent>(state.process->GetHandle(handle))->ResetSignal();
             LOGD("Clearing 0x{:X}", handle);
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
             return;
         }
     }
 
-    void MapSharedMemory(const DeviceState &state) {
+    void MapSharedMemory(const DeviceState &state, SvcContext &ctx) {
         try {
-            KHandle handle{state.ctx->gpr.w0};
+            KHandle handle{ctx.w0};
             auto object{state.process->GetHandle<type::KSharedMemory>(handle)};
-            u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x1)};
+            u8 *address{reinterpret_cast<u8 *>(ctx.x1)};
 
             if (!util::IsPageAligned(address)) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidAddress;
+                ctx.w0 = result::InvalidAddress;
                 LOGW("'address' not page aligned: {}", fmt::ptr(address));
                 return;
             }
 
-            size_t size{state.ctx->gpr.x2};
+            size_t size{ctx.x2};
             if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidSize;
+                ctx.w0 = result::InvalidSize;
                 LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
                 return;
             }
 
             if (address >= (address + size) || !state.process->memory.AddressSpaceContains(span<u8>{address, size})) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+                ctx.w0 = result::InvalidCurrentMemory;
                 LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X}", fmt::ptr(address), size);
                 return;
             }
 
-            memory::Permission permission(static_cast<u8>(state.ctx->gpr.w3));
+            memory::Permission permission(static_cast<u8>(ctx.w3));
             if ((!permission.r && !permission.w && !permission.x) || (permission.w && !permission.r) || permission.x) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidNewMemoryPermission;
+                ctx.w0 = result::InvalidNewMemoryPermission;
                 LOGW("'permission' invalid: {}", permission);
                 return;
             }
@@ -532,34 +532,34 @@ namespace skyline::kernel::svc {
             object->Map(span<u8>{address, size}, permission);
             state.process->memory.AddRef(object);
 
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
-            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(state.ctx->gpr.w0));
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(ctx.w0));
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void UnmapSharedMemory(const DeviceState &state) {
+    void UnmapSharedMemory(const DeviceState &state, SvcContext &ctx) {
         try {
-            KHandle handle{state.ctx->gpr.w0};
+            KHandle handle{ctx.w0};
             auto object{state.process->GetHandle<type::KSharedMemory>(handle)};
-            u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x1)};
+            u8 *address{reinterpret_cast<u8 *>(ctx.x1)};
 
             if (!util::IsPageAligned(address)) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidAddress;
+                ctx.w0 = result::InvalidAddress;
                 LOGW("'address' not page aligned: {}", fmt::ptr(address));
                 return;
             }
 
-            size_t size{state.ctx->gpr.x2};
+            size_t size{ctx.x2};
             if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidSize;
+                ctx.w0 = result::InvalidSize;
                 LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
                 return;
             }
 
             if (address >= (address + size) || !state.process->memory.AddressSpaceContains(span<u8>{address, size})) [[unlikely]] {
-                state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+                ctx.w0 = result::InvalidCurrentMemory;
                 LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X}", fmt::ptr(address), size);
                 return;
             }
@@ -569,102 +569,102 @@ namespace skyline::kernel::svc {
             object->Unmap(span<u8>{address, size});
             state.process->memory.RemoveRef(object);
 
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
-            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(state.ctx->gpr.w0));
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(ctx.w0));
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void CreateTransferMemory(const DeviceState &state) {
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x1)};
+    void CreateTransferMemory(const DeviceState &state, SvcContext &ctx) {
+        u8 *address{reinterpret_cast<u8 *>(ctx.x1)};
         if (!util::IsPageAligned(address)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("'address' not page aligned: {}", fmt::ptr(address));
             return;
         }
 
-        size_t size{state.ctx->gpr.x2};
+        size_t size{ctx.x2};
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (address >= (address + size) || !state.process->memory.AddressSpaceContains(span<u8>{address, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidCurrentMemory;
+            ctx.w0 = result::InvalidCurrentMemory;
             LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X}", fmt::ptr(address), size);
             return;
         }
 
-        memory::Permission permission(static_cast<u8>(state.ctx->gpr.w3));
+        memory::Permission permission(static_cast<u8>(ctx.w3));
         if ((permission.w && !permission.r) || permission.x) [[unlikely]] {
             LOGW("'permission' invalid: {}", permission);
-            state.ctx->gpr.w0 = result::InvalidNewMemoryPermission;
+            ctx.w0 = result::InvalidNewMemoryPermission;
             return;
         }
 
         auto tmem{state.process->NewHandle<kernel::type::KTransferMemory>(size)};
         if (!tmem.item->Map(span<u8>{address, size}, permission)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidState;
+            ctx.w0 = result::InvalidState;
             return;
         }
 
         LOGD("Creating transfer memory (0x{:X}) at {} - {} (0x{:X} bytes) ({}{}{})", tmem.handle, fmt::ptr(address), fmt::ptr(address + size), size, permission.r ? 'R' : '-', permission.w ? 'W' : '-', permission.x ? 'X' : '-');
 
-        state.ctx->gpr.w0 = Result{};
-        state.ctx->gpr.w1 = tmem.handle;
+        ctx.w0 = Result{};
+        ctx.w1 = tmem.handle;
     }
 
-    void CloseHandle(const DeviceState &state) {
-        KHandle handle{static_cast<KHandle>(state.ctx->gpr.w0)};
+    void CloseHandle(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{static_cast<KHandle>(ctx.w0)};
         try {
             state.process->CloseHandle(handle);
             LOGD("Closing 0x{:X}", handle);
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void ResetSignal(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w0};
+    void ResetSignal(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w0};
         TRACE_EVENT_FMT("kernel", "ResetSignal 0x{:X}", handle);
         try {
             auto object{state.process->GetHandle(handle)};
             switch (object->objectType) {
                 case type::KType::KEvent:
                 case type::KType::KProcess:
-                    state.ctx->gpr.w0 = std::static_pointer_cast<type::KSyncObject>(object)->ResetSignal() ? Result{} : result::InvalidState;
+                    ctx.w0 = std::static_pointer_cast<type::KSyncObject>(object)->ResetSignal() ? Result{} : result::InvalidState;
                     break;
 
                 default: {
                     LOGW("'handle' type invalid: 0x{:X} ({})", handle, object->objectType);
-                    state.ctx->gpr.w0 = result::InvalidHandle;
+                    ctx.w0 = result::InvalidHandle;
                     return;
                 }
             }
 
             LOGD("Resetting 0x{:X}", handle);
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", handle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
             return;
         }
     }
 
-    void WaitSynchronization(const DeviceState &state) {
+    void WaitSynchronization(const DeviceState &state, SvcContext &ctx) {
         constexpr u8 MaxSyncHandles{0x40}; // The total amount of handles that can be passed to WaitSynchronization
 
-        u32 numHandles{state.ctx->gpr.w2};
+        u32 numHandles{ctx.w2};
         if (numHandles > MaxSyncHandles) {
-            state.ctx->gpr.w0 = result::OutOfRange;
+            ctx.w0 = result::OutOfRange;
             return;
         }
 
-        span waitHandles(reinterpret_cast<KHandle *>(state.ctx->gpr.x1), numHandles);
+        span waitHandles(reinterpret_cast<KHandle *>(ctx.x1), numHandles);
         std::vector<std::shared_ptr<type::KSyncObject>> objectTable;
         objectTable.reserve(numHandles);
 
@@ -680,13 +680,13 @@ namespace skyline::kernel::svc {
 
                 default: {
                     LOGD("An invalid handle was supplied: 0x{:X}", handle);
-                    state.ctx->gpr.w0 = result::InvalidHandle;
+                    ctx.w0 = result::InvalidHandle;
                     return;
                 }
             }
         }
 
-        i64 timeout{static_cast<i64>(state.ctx->gpr.x3)};
+        i64 timeout{static_cast<i64>(ctx.x3)};
         if (waitHandles.size() == 1) {
             LOGD("Waiting on 0x{:X} for {}ns", waitHandles[0], timeout);
         } else if (AsyncLogger::CheckLogLevel(AsyncLogger::LogLevel::Debug)) {
@@ -701,7 +701,7 @@ namespace skyline::kernel::svc {
         std::unique_lock lock(type::KSyncObject::syncObjectMutex);
         if (state.thread->cancelSync) {
             state.thread->cancelSync = false;
-            state.ctx->gpr.w0 = result::Cancelled;
+            ctx.w0 = result::Cancelled;
             return;
         }
 
@@ -709,8 +709,8 @@ namespace skyline::kernel::svc {
         for (const auto &object : objectTable) {
             if (object->signalled) {
                 LOGD("Signalled 0x{:X}", waitHandles[index]);
-                state.ctx->gpr.w0 = Result{};
-                state.ctx->gpr.w1 = index;
+                ctx.w0 = Result{};
+                ctx.w1 = index;
                 return;
             }
             index++;
@@ -718,7 +718,7 @@ namespace skyline::kernel::svc {
 
         if (timeout == 0) {
             LOGD("No handle is currently signalled");
-            state.ctx->gpr.w0 = result::TimedOut;
+            ctx.w0 = result::TimedOut;
             return;
         }
 
@@ -757,50 +757,50 @@ namespace skyline::kernel::svc {
 
         if (wakeObject) {
             LOGD("Signalled 0x{:X}", waitHandles[wakeIndex]);
-            state.ctx->gpr.w0 = Result{};
-            state.ctx->gpr.w1 = wakeIndex;
+            ctx.w0 = Result{};
+            ctx.w1 = wakeIndex;
         } else if (state.thread->cancelSync) {
             state.thread->cancelSync = false;
             LOGD("Wait has been cancelled");
-            state.ctx->gpr.w0 = result::Cancelled;
+            ctx.w0 = result::Cancelled;
         } else {
             LOGD("Wait has timed out");
-            state.ctx->gpr.w0 = result::TimedOut;
+            ctx.w0 = result::TimedOut;
             lock.unlock();
             state.scheduler->InsertThread(state.thread);
             state.scheduler->WaitSchedule();
         }
     }
 
-    void CancelSynchronization(const DeviceState &state) {
+    void CancelSynchronization(const DeviceState &state, SvcContext &ctx) {
         try {
             std::unique_lock lock(type::KSyncObject::syncObjectMutex);
-            auto thread{state.process->GetHandle<type::KThread>(state.ctx->gpr.w0)};
+            auto thread{state.process->GetHandle<type::KThread>(ctx.w0)};
             LOGD("Cancelling Synchronization {}", thread->id);
             thread->cancelSync = true;
             if (thread->isCancellable) {
                 thread->isCancellable = false;
                 state.scheduler->InsertThread(thread);
             }
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
-            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(state.ctx->gpr.w0));
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(ctx.w0));
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void ArbitrateLock(const DeviceState &state) {
-        auto mutex{reinterpret_cast<u32 *>(state.ctx->gpr.x1)};
+    void ArbitrateLock(const DeviceState &state, SvcContext &ctx) {
+        auto mutex{reinterpret_cast<u32 *>(ctx.x1)};
         if (!util::IsWordAligned(mutex)) {
             LOGW("'mutex' not word aligned: {}", fmt::ptr(mutex));
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             return;
         }
 
         LOGD("Locking {}", fmt::ptr(mutex));
 
-        KHandle ownerHandle{state.ctx->gpr.w0};
-        KHandle requesterHandle{state.ctx->gpr.w2};
+        KHandle ownerHandle{ctx.w0};
+        KHandle requesterHandle{ctx.w2};
         auto result{state.process->MutexLock(state.thread, mutex, ownerHandle, requesterHandle)};
         if (result == Result{})
             LOGD("Locked {}", fmt::ptr(mutex));
@@ -809,14 +809,14 @@ namespace skyline::kernel::svc {
         else if (result == result::InvalidHandle)
             LOGW("'ownerHandle' invalid: 0x{:X} ({})", ownerHandle, fmt::ptr(mutex));
 
-        state.ctx->gpr.w0 = result;
+        ctx.w0 = result;
     }
 
-    void ArbitrateUnlock(const DeviceState &state) {
-        auto mutex{reinterpret_cast<u32 *>(state.ctx->gpr.x0)};
+    void ArbitrateUnlock(const DeviceState &state, SvcContext &ctx) {
+        auto mutex{reinterpret_cast<u32 *>(ctx.x0)};
         if (!util::IsWordAligned(mutex)) {
             LOGW("'mutex' not word aligned: {}", fmt::ptr(mutex));
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             return;
         }
 
@@ -824,21 +824,21 @@ namespace skyline::kernel::svc {
         state.process->MutexUnlock(mutex);
         LOGD("Unlocked {}", fmt::ptr(mutex));
 
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void WaitProcessWideKeyAtomic(const DeviceState &state) {
-        auto mutex{reinterpret_cast<u32 *>(state.ctx->gpr.x0)};
+    void WaitProcessWideKeyAtomic(const DeviceState &state, SvcContext &ctx) {
+        auto mutex{reinterpret_cast<u32 *>(ctx.x0)};
         if (!util::IsWordAligned(mutex)) {
             LOGW("'mutex' not word aligned: {}", fmt::ptr(mutex));
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             return;
         }
 
-        auto conditional{reinterpret_cast<u32 *>(state.ctx->gpr.x1)};
-        KHandle requesterHandle{state.ctx->gpr.w2};
+        auto conditional{reinterpret_cast<u32 *>(ctx.x1)};
+        KHandle requesterHandle{ctx.w2};
 
-        i64 timeout{static_cast<i64>(state.ctx->gpr.x3)};
+        i64 timeout{static_cast<i64>(ctx.x3)};
         LOGD("Waiting on {} with {} for {}ns", fmt::ptr(conditional), fmt::ptr(mutex), timeout);
 
         auto result{state.process->ConditionVariableWait(conditional, mutex, requesterHandle, timeout)};
@@ -846,19 +846,19 @@ namespace skyline::kernel::svc {
             LOGD("Waited for {} and reacquired {}", fmt::ptr(conditional), fmt::ptr(mutex));
         else if (result == result::TimedOut)
             LOGD("Wait on {} has timed out after {}ns", fmt::ptr(conditional), timeout);
-        state.ctx->gpr.w0 = result;
+        ctx.w0 = result;
     }
 
-    void SignalProcessWideKey(const DeviceState &state) {
-        auto conditional{reinterpret_cast<u32 *>(state.ctx->gpr.x0)};
-        i32 count{static_cast<i32>(state.ctx->gpr.w1)};
+    void SignalProcessWideKey(const DeviceState &state, SvcContext &ctx) {
+        auto conditional{reinterpret_cast<u32 *>(ctx.x0)};
+        i32 count{static_cast<i32>(ctx.w1)};
 
         LOGD("Signalling {} for {} waiters", fmt::ptr(conditional), count);
         state.process->ConditionVariableSignal(conditional, count);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void GetSystemTick(const DeviceState &state) {
+    void GetSystemTick(const DeviceState &state, SvcContext &ctx) {
         u64 tick;
         asm("STR X1, [SP, #-16]!\n\t"
             "MRS %0, CNTVCT_EL0\n\t"
@@ -868,46 +868,46 @@ namespace skyline::kernel::svc {
             "MRS X1, CNTFRQ_EL0\n\t"
             "UDIV %0, %0, X1\n\t"
             "LDR X1, [SP], #16" : "=r"(tick));
-        state.ctx->gpr.x0 = tick;
+        ctx.x0 = tick;
     }
 
-    void ConnectToNamedPort(const DeviceState &state) {
+    void ConnectToNamedPort(const DeviceState &state, SvcContext &ctx) {
         constexpr u8 portSize = 0x8; //!< The size of a port name string
-        std::string_view port(span(reinterpret_cast<char *>(state.ctx->gpr.x1), portSize).as_string(true));
+        std::string_view port(span(reinterpret_cast<char *>(ctx.x1), portSize).as_string(true));
 
         KHandle handle{};
         if (port.compare("sm:") >= 0) {
             handle = state.process->NewHandle<type::KSession>(std::static_pointer_cast<service::BaseService>(state.os->serviceManager.smUserInterface)).handle;
         } else {
             LOGW("Connecting to invalid port: '{}'", port);
-            state.ctx->gpr.w0 = result::NotFound;
+            ctx.w0 = result::NotFound;
             return;
         }
 
         LOGD("Connecting to port '{}' at 0x{:X}", port, handle);
 
-        state.ctx->gpr.w1 = handle;
-        state.ctx->gpr.w0 = Result{};
+        ctx.w1 = handle;
+        ctx.w0 = Result{};
     }
 
-    void SendSyncRequest(const DeviceState &state) {
+    void SendSyncRequest(const DeviceState &state, SvcContext &ctx) {
         SchedulerScopedLock schedulerLock(state);
-        state.os->serviceManager.SyncRequestHandler(static_cast<KHandle>(state.ctx->gpr.x0));
-        state.ctx->gpr.w0 = Result{};
+        state.os->serviceManager.SyncRequestHandler(static_cast<KHandle>(ctx.x0));
+        ctx.w0 = Result{};
     }
 
-    void GetThreadId(const DeviceState &state) {
-        KHandle handle{state.ctx->gpr.w1};
+    void GetThreadId(const DeviceState &state, SvcContext &ctx) {
+        KHandle handle{ctx.w1};
         size_t tid{state.process->GetHandle<type::KThread>(handle)->id};
 
         LOGD("0x{:X} -> #{}", handle, tid);
 
-        state.ctx->gpr.x1 = tid;
-        state.ctx->gpr.w0 = Result{};
+        ctx.x1 = tid;
+        ctx.w0 = Result{};
     }
 
-    void Break(const DeviceState &state) {
-        auto reason{state.ctx->gpr.x0};
+    void Break(const DeviceState &state, SvcContext &ctx) {
+        auto reason{ctx.x0};
         if (reason & (1ULL << 31)) {
             LOGD("Debugger is being engaged ({})", reason);
         } else {
@@ -918,17 +918,17 @@ namespace skyline::kernel::svc {
         }
     }
 
-    void OutputDebugString(const DeviceState &state) {
-        auto string{span(reinterpret_cast<char *>(state.ctx->gpr.x0), state.ctx->gpr.x1).as_string()};
+    void OutputDebugString(const DeviceState &state, SvcContext &ctx) {
+        auto string{span(reinterpret_cast<char *>(ctx.x0), ctx.x1).as_string()};
 
         if (string.back() == '\n')
             string.remove_suffix(1);
 
         LOGI("{}", string);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void GetInfo(const DeviceState &state) {
+    void GetInfo(const DeviceState &state, SvcContext &ctx) {
         enum class InfoState : u32 {
             // 1.0.0+
             AllowedCpuIdBitmask = 0,
@@ -961,9 +961,9 @@ namespace skyline::kernel::svc {
             TotalMemoryUsageWithoutSystemResource = 22,
         };
 
-        InfoState info{static_cast<u32>(state.ctx->gpr.w1)};
-        KHandle handle{state.ctx->gpr.w2};
-        u64 id1{state.ctx->gpr.x3};
+        InfoState info{static_cast<u32>(ctx.w1)};
+        KHandle handle{ctx.w2};
+        u64 id1{ctx.x3};
 
         constexpr u64 totalPhysicalMemory{0xF8000000}; // ~4 GB of RAM
 
@@ -1056,40 +1056,40 @@ namespace skyline::kernel::svc {
 
             default:
                 LOGW("Unimplemented case ID0: {}, ID1: {}", static_cast<u32>(info), id1);
-                state.ctx->gpr.w0 = result::InvalidEnumValue;
+                ctx.w0 = result::InvalidEnumValue;
                 return;
         }
 
         LOGD("ID0: {}, ID1: {}, Out: 0x{:X}", static_cast<u32>(info), id1, out);
 
-        state.ctx->gpr.x1 = out;
-        state.ctx->gpr.w0 = Result{};
+        ctx.x1 = out;
+        ctx.w0 = Result{};
     }
 
-    void MapPhysicalMemory(const DeviceState &state) {
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
-        size_t size{state.ctx->gpr.x1};
+    void MapPhysicalMemory(const DeviceState &state, SvcContext &ctx) {
+        u8 *address{reinterpret_cast<u8 *>(ctx.x0)};
+        size_t size{ctx.x1};
 
         if (!util::IsPageAligned(address)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("'address' not page aligned: {}", fmt::ptr(address));
             return;
         }
 
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (address >= (address + size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidMemoryRegion;
+            ctx.w0 = result::InvalidMemoryRegion;
             LOGW("Invalid address and size combination: 'address': {}, 'size': 0x{:X}", fmt::ptr(address), size);
             return;
         }
 
         if (!state.process->memory.alias.guest.contains(span<u8>{address, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidMemoryRegion;
+            ctx.w0 = result::InvalidMemoryRegion;
             LOGW("Tried to map physical memory outside of alias region: {} - {} (0x{:X} bytes)", fmt::ptr(address), fmt::ptr(address + size), size);
             return;
         }
@@ -1097,27 +1097,27 @@ namespace skyline::kernel::svc {
         state.process->memory.MapHeapMemory(span<u8>{address, size});
 
         LOGD("Mapped physical memory at {} - {} (0x{:X} bytes)", fmt::ptr(address), fmt::ptr(address + size), size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void UnmapPhysicalMemory(const DeviceState &state) {
-        u8 *address{reinterpret_cast<u8 *>(state.ctx->gpr.x0)};
-        size_t size{state.ctx->gpr.x1};
+    void UnmapPhysicalMemory(const DeviceState &state, SvcContext &ctx) {
+        u8 *address{reinterpret_cast<u8 *>(ctx.x0)};
+        size_t size{ctx.x1};
 
         if (!util::IsPageAligned(address)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             LOGW("'address' not page aligned: {}", fmt::ptr(address));
             return;
         }
 
         if (!size || !util::IsPageAligned(size)) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidSize;
+            ctx.w0 = result::InvalidSize;
             LOGW("'size' {}: 0x{:X}", size ? "is not page aligned" : "is zero", size);
             return;
         }
 
         if (!state.process->memory.alias.guest.contains(span<u8>{address, size})) [[unlikely]] {
-            state.ctx->gpr.w0 = result::InvalidMemoryRegion;
+            ctx.w0 = result::InvalidMemoryRegion;
             LOGW("Tried to unmap physical memory outside of alias region: {} - {} (0x{:X} bytes)", fmt::ptr(address), fmt::ptr(address + size), size);
             return;
         }
@@ -1125,11 +1125,11 @@ namespace skyline::kernel::svc {
         state.process->memory.UnmapMemory(span<u8>{address, size});
 
         LOGD("Unmapped physical memory at {} - {} (0x{:X} bytes)", fmt::ptr(address), fmt::ptr(address + size), size);
-        state.ctx->gpr.w0 = Result{};
+        ctx.w0 = Result{};
     }
 
-    void SetThreadActivity(const DeviceState &state) {
-        u32 activityValue{static_cast<u32>(state.ctx->gpr.w1)};
+    void SetThreadActivity(const DeviceState &state, SvcContext &ctx) {
+        u32 activityValue{static_cast<u32>(ctx.w1)};
         enum class ThreadActivity : u32 {
             Runnable = 0,
             Paused = 1,
@@ -1142,16 +1142,16 @@ namespace skyline::kernel::svc {
 
             default:
                 LOGW("Invalid thread activity: {}", static_cast<u32>(activity));
-                state.ctx->gpr.w0 = result::InvalidEnumValue;
+                ctx.w0 = result::InvalidEnumValue;
                 return;
         }
 
-        KHandle threadHandle{state.ctx->gpr.w0};
+        KHandle threadHandle{ctx.w0};
         try {
             auto thread{state.process->GetHandle<type::KThread>(threadHandle)};
             if (thread == state.thread) {
                 LOGW("Thread setting own activity: {} (Thread: 0x{:X})", static_cast<u32>(activity), threadHandle);
-                state.ctx->gpr.w0 = result::Busy;
+                ctx.w0 = result::Busy;
                 return;
             }
 
@@ -1162,7 +1162,7 @@ namespace skyline::kernel::svc {
                     state.scheduler->ResumeThread(thread);
                 } else {
                     LOGW("Attempting to resume thread which is already runnable (Thread: 0x{:X})", threadHandle);
-                    state.ctx->gpr.w0 = result::InvalidState;
+                    ctx.w0 = result::InvalidState;
                     return;
                 }
             } else if (activity == ThreadActivity::Paused) {
@@ -1171,32 +1171,32 @@ namespace skyline::kernel::svc {
                     state.scheduler->PauseThread(thread);
                 } else {
                     LOGW("Attempting to pause thread which is already paused (Thread: 0x{:X})", threadHandle);
-                    state.ctx->gpr.w0 = result::InvalidState;
+                    ctx.w0 = result::InvalidState;
                     return;
                 }
             }
 
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", static_cast<u32>(threadHandle));
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void GetThreadContext3(const DeviceState &state) {
-        KHandle threadHandle{state.ctx->gpr.w1};
+    void GetThreadContext3(const DeviceState &state, SvcContext &ctx) {
+        KHandle threadHandle{ctx.w1};
         try {
             auto thread{state.process->GetHandle<type::KThread>(threadHandle)};
             if (thread == state.thread) {
                 LOGW("Thread attempting to retrieve own context");
-                state.ctx->gpr.w0 = result::Busy;
+                ctx.w0 = result::Busy;
                 return;
             }
 
             std::scoped_lock guard{thread->coreMigrationMutex};
             if (!thread->isPaused) {
                 LOGW("Attemping to get context of running thread #{}", thread->id);
-                state.ctx->gpr.w0 = result::InvalidState;
+                ctx.w0 = result::InvalidState;
                 return;
             }
 
@@ -1215,7 +1215,7 @@ namespace skyline::kernel::svc {
             };
             static_assert(sizeof(ThreadContext) == 0x320);
 
-            auto &context{*reinterpret_cast<ThreadContext *>(state.ctx->gpr.x0)};
+            auto &context{*reinterpret_cast<ThreadContext *>(ctx.x0)};
             context = {}; // Zero-initialize the contents of the context as not all fields are set
 
             auto &targetContext{thread->ctx};
@@ -1233,25 +1233,25 @@ namespace skyline::kernel::svc {
             // Note: We don't write the whole context as we only store the parts required according to the ARMv8 ABI for syscall handling
             LOGD("Written partial context for thread #{}", thread->id);
 
-            state.ctx->gpr.w0 = Result{};
+            ctx.w0 = Result{};
         } catch (const std::out_of_range &) {
             LOGW("'handle' invalid: 0x{:X}", threadHandle);
-            state.ctx->gpr.w0 = result::InvalidHandle;
+            ctx.w0 = result::InvalidHandle;
         }
     }
 
-    void WaitForAddress(const DeviceState &state) {
-        auto address{reinterpret_cast<u32 *>(state.ctx->gpr.x0)};
+    void WaitForAddress(const DeviceState &state, SvcContext &ctx) {
+        auto address{reinterpret_cast<u32 *>(ctx.x0)};
         if (!util::IsWordAligned(address)) [[unlikely]] {
             LOGW("'address' not word aligned: {}", fmt::ptr(address));
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             return;
         }
 
         using ArbitrationType = type::KProcess::ArbitrationType;
-        auto arbitrationType{static_cast<ArbitrationType>(static_cast<u32>(state.ctx->gpr.w1))};
-        u32 value{state.ctx->gpr.w2};
-        i64 timeout{static_cast<i64>(state.ctx->gpr.x3)};
+        auto arbitrationType{static_cast<ArbitrationType>(static_cast<u32>(ctx.w1))};
+        u32 value{ctx.w2};
+        i64 timeout{static_cast<i64>(ctx.x3)};
 
         Result result;
         switch (arbitrationType) {
@@ -1272,34 +1272,34 @@ namespace skyline::kernel::svc {
 
             default:
                 [[unlikely]]
-                    LOGE("'arbitrationType' invalid: {}", arbitrationType);
-                state.ctx->gpr.w0 = result::InvalidEnumValue;
+                LOGE("'arbitrationType' invalid: {}", arbitrationType);
+                ctx.w0 = result::InvalidEnumValue;
                 return;
         }
 
         if (result == Result{})
             [[likely]]
-                LOGD("Waited on {} successfully", fmt::ptr(address));
+            LOGD("Waited on {} successfully", fmt::ptr(address));
         else if (result == result::TimedOut)
             LOGD("Wait on {} has timed out after {}ns", fmt::ptr(address), timeout);
         else if (result == result::InvalidState)
             LOGD("The value at {} did not satisfy the arbitration condition", fmt::ptr(address));
 
-        state.ctx->gpr.w0 = result;
+        ctx.w0 = result;
     }
 
-    void SignalToAddress(const DeviceState &state) {
-        auto address{reinterpret_cast<u32 *>(state.ctx->gpr.x0)};
+    void SignalToAddress(const DeviceState &state, SvcContext &ctx) {
+        auto address{reinterpret_cast<u32 *>(ctx.x0)};
         if (!util::IsWordAligned(address)) [[unlikely]] {
             LOGW("'address' not word aligned: {}", fmt::ptr(address));
-            state.ctx->gpr.w0 = result::InvalidAddress;
+            ctx.w0 = result::InvalidAddress;
             return;
         }
 
         using SignalType = type::KProcess::SignalType;
-        auto signalType{static_cast<SignalType>(static_cast<u32>(state.ctx->gpr.w1))};
-        u32 value{state.ctx->gpr.w2};
-        i32 count{static_cast<i32>(state.ctx->gpr.w3)};
+        auto signalType{static_cast<SignalType>(static_cast<u32>(ctx.w1))};
+        u32 value{ctx.w2};
+        i32 count{static_cast<i32>(ctx.w3)};
 
         Result result;
         switch (signalType) {
@@ -1320,8 +1320,8 @@ namespace skyline::kernel::svc {
 
             default:
                 [[unlikely]]
-                    LOGE("'signalType' invalid: {}", signalType);
-                state.ctx->gpr.w0 = result::InvalidEnumValue;
+                LOGE("'signalType' invalid: {}", signalType);
+                ctx.w0 = result::InvalidEnumValue;
                 return;
         }
 
@@ -1331,6 +1331,6 @@ namespace skyline::kernel::svc {
         else if (result == result::InvalidState)
             LOGD("The value at {} did not satisfy the mutation condition", fmt::ptr(address));
 
-        state.ctx->gpr.w0 = result;
+        ctx.w0 = result;
     }
 }

--- a/app/src/main/cpp/skyline/kernel/svc.h
+++ b/app/src/main/cpp/skyline/kernel/svc.h
@@ -254,7 +254,7 @@ namespace skyline::kernel::svc {
     void SignalToAddress(const DeviceState &state, SvcContext &ctx);
 
     /**
-     * @brief A per-SVC descriptor with it's name and a function pointer
+     * @brief A per-SVC descriptor with its name and a function pointer
      * @note The descriptor is nullable, the validity of the descriptor can be checked with the boolean operator
      */
     struct SvcDescriptor {
@@ -266,145 +266,8 @@ namespace skyline::kernel::svc {
         }
     };
 
-    #define SVC_NONE SvcDescriptor{} //!< A macro with a placeholder value for the SVC not being implemented or not existing
-    #define SVC_STRINGIFY(name) #name
-    #define SVC_ENTRY(function) SvcDescriptor{function, SVC_STRINGIFY(Svc ## function)} //!< A macro which automatically stringifies the function name as the name to prevent pointless duplication
-
     /**
-     * @brief The SVC table maps all SVCs to their corresponding functions
+     * @brief The SVC table that maps all SVCs to their corresponding functions
      */
-    static constexpr std::array<SvcDescriptor, 0x80> SvcTable{
-        SVC_NONE, // 0x00 (Does not exist)
-        SVC_ENTRY(SetHeapSize), // 0x01
-        SVC_ENTRY(SetMemoryPermission), // 0x02
-        SVC_ENTRY(SetMemoryAttribute), // 0x03
-        SVC_ENTRY(MapMemory), // 0x04
-        SVC_ENTRY(UnmapMemory), // 0x05
-        SVC_ENTRY(QueryMemory), // 0x06
-        SVC_ENTRY(ExitProcess), // 0x07
-        SVC_ENTRY(CreateThread), // 0x08
-        SVC_ENTRY(StartThread), // 0x09
-        SVC_ENTRY(ExitThread), // 0x0A
-        SVC_ENTRY(SleepThread), // 0x0B
-        SVC_ENTRY(GetThreadPriority), // 0x0C
-        SVC_ENTRY(SetThreadPriority), // 0x0D
-        SVC_ENTRY(GetThreadCoreMask), // 0x0E
-        SVC_ENTRY(SetThreadCoreMask), // 0x0F
-        SVC_ENTRY(GetCurrentProcessorNumber), // 0x10
-        SVC_NONE, // 0x11
-        SVC_ENTRY(ClearEvent), // 0x12
-        SVC_ENTRY(MapSharedMemory), // 0x13
-        SVC_ENTRY(UnmapSharedMemory), // 0x14
-        SVC_ENTRY(CreateTransferMemory), // 0x15
-        SVC_ENTRY(CloseHandle), // 0x16
-        SVC_ENTRY(ResetSignal), // 0x17
-        SVC_ENTRY(WaitSynchronization), // 0x18
-        SVC_ENTRY(CancelSynchronization), // 0x19
-        SVC_ENTRY(ArbitrateLock), // 0x1A
-        SVC_ENTRY(ArbitrateUnlock), // 0x1B
-        SVC_ENTRY(WaitProcessWideKeyAtomic), // 0x1C
-        SVC_ENTRY(SignalProcessWideKey), // 0x1D
-        SVC_ENTRY(GetSystemTick), // 0x1E
-        SVC_ENTRY(ConnectToNamedPort), // 0x1F
-        SVC_NONE, // 0x20
-        SVC_ENTRY(SendSyncRequest), // 0x21
-        SVC_NONE, // 0x22
-        SVC_NONE, // 0x23
-        SVC_NONE, // 0x24
-        SVC_ENTRY(GetThreadId), // 0x25
-        SVC_ENTRY(Break), // 0x26
-        SVC_ENTRY(OutputDebugString), // 0x27
-        SVC_NONE, // 0x28
-        SVC_ENTRY(GetInfo), // 0x29
-        SVC_NONE, // 0x2A
-        SVC_NONE, // 0x2B
-        SVC_ENTRY(MapPhysicalMemory), // 0x2C
-        SVC_ENTRY(UnmapPhysicalMemory), // 0x2D
-        SVC_NONE, // 0x2E
-        SVC_NONE, // 0x2F
-        SVC_NONE, // 0x30
-        SVC_NONE, // 0x31
-        SVC_ENTRY(SetThreadActivity), // 0x32
-        SVC_ENTRY(GetThreadContext3), // 0x33
-        SVC_ENTRY(WaitForAddress), // 0x34
-        SVC_ENTRY(SignalToAddress), // 0x35
-        SVC_NONE, // 0x36
-        SVC_NONE, // 0x37
-        SVC_NONE, // 0x38
-        SVC_NONE, // 0x39
-        SVC_NONE, // 0x3A
-        SVC_NONE, // 0x3B
-        SVC_NONE, // 0x3C
-        SVC_NONE, // 0x3D
-        SVC_NONE, // 0x3E
-        SVC_NONE, // 0x3F
-        SVC_NONE, // 0x40
-        SVC_NONE, // 0x41
-        SVC_NONE, // 0x42
-        SVC_NONE, // 0x43
-        SVC_NONE, // 0x44
-        SVC_NONE, // 0x45
-        SVC_NONE, // 0x46
-        SVC_NONE, // 0x47
-        SVC_NONE, // 0x48
-        SVC_NONE, // 0x49
-        SVC_NONE, // 0x4A
-        SVC_NONE, // 0x4B
-        SVC_NONE, // 0x4C
-        SVC_NONE, // 0x4D
-        SVC_NONE, // 0x4E
-        SVC_NONE, // 0x4F
-        SVC_NONE, // 0x50
-        SVC_NONE, // 0x51
-        SVC_NONE, // 0x52
-        SVC_NONE, // 0x53
-        SVC_NONE, // 0x54
-        SVC_NONE, // 0x55
-        SVC_NONE, // 0x56
-        SVC_NONE, // 0x57
-        SVC_NONE, // 0x58
-        SVC_NONE, // 0x59
-        SVC_NONE, // 0x5A
-        SVC_NONE, // 0x5B
-        SVC_NONE, // 0x5C
-        SVC_NONE, // 0x5D
-        SVC_NONE, // 0x5E
-        SVC_NONE, // 0x5F
-        SVC_NONE, // 0x60
-        SVC_NONE, // 0x61
-        SVC_NONE, // 0x62
-        SVC_NONE, // 0x63
-        SVC_NONE, // 0x64
-        SVC_NONE, // 0x65
-        SVC_NONE, // 0x66
-        SVC_NONE, // 0x67
-        SVC_NONE, // 0x68
-        SVC_NONE, // 0x69
-        SVC_NONE, // 0x6A
-        SVC_NONE, // 0x6B
-        SVC_NONE, // 0x6C
-        SVC_NONE, // 0x6D
-        SVC_NONE, // 0x6E
-        SVC_NONE, // 0x6F
-        SVC_NONE, // 0x70
-        SVC_NONE, // 0x71
-        SVC_NONE, // 0x72
-        SVC_NONE, // 0x73
-        SVC_NONE, // 0x74
-        SVC_NONE, // 0x75
-        SVC_NONE, // 0x76
-        SVC_NONE, // 0x77
-        SVC_NONE, // 0x78
-        SVC_NONE, // 0x79
-        SVC_NONE, // 0x7A
-        SVC_NONE, // 0x7B
-        SVC_NONE, // 0x7C
-        SVC_NONE, // 0x7D
-        SVC_NONE, // 0x7E
-        SVC_NONE // 0x7F
-    };
-
-    #undef SVC_NONE
-    #undef SVC_STRINGIFY
-    #undef SVC_ENTRY
+    extern const std::array<SvcDescriptor, 0x80> SvcTable;
 }

--- a/app/src/main/cpp/skyline/kernel/svc.h
+++ b/app/src/main/cpp/skyline/kernel/svc.h
@@ -4,261 +4,262 @@
 #pragma once
 
 #include <common.h>
+#include "svc_context.h"
 
 namespace skyline::kernel::svc {
     /**
      * @brief Sets the process heap to a given size, it can both extend and shrink the heap
      * @url https://switchbrew.org/wiki/SVC#SetHeapSize
      */
-    void SetHeapSize(const DeviceState &state);
+    void SetHeapSize(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Reprotects a page-aligned memory region.
      * @url https://switchbrew.org/wiki/SVC#SetMemoryPermission
      */
-    void SetMemoryPermission(const DeviceState &state);
+    void SetMemoryPermission(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Change attribute of page-aligned memory region, this is used to turn on/off caching for a given memory area
      * @url https://switchbrew.org/wiki/SVC#SetMemoryAttribute
      */
-    void SetMemoryAttribute(const DeviceState &state);
+    void SetMemoryAttribute(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Maps a memory range into a different range, mainly used for adding guard pages around stack
      * @url https://switchbrew.org/wiki/SVC#MapMemory
      */
-    void MapMemory(const DeviceState &state);
+    void MapMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Unmaps a region that was previously mapped with #MapMemory
      * @url https://switchbrew.org/wiki/SVC#UnmapMemory
      */
-    void UnmapMemory(const DeviceState &state);
+    void UnmapMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Query information about an address
      * @url https://switchbrew.org/wiki/SVC#QueryMemory
      */
-    void QueryMemory(const DeviceState &state);
+    void QueryMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Exits the current process
      * @url https://switchbrew.org/wiki/SVC#ExitProcess
      */
-    void ExitProcess(const DeviceState &state);
+    void ExitProcess(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Create a thread in the current process
      * @url https://switchbrew.org/wiki/SVC#CreateThread
      */
-    void CreateThread(const DeviceState &state);
+    void CreateThread(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Starts the thread for the provided handle
      * @url https://switchbrew.org/wiki/SVC#StartThread
      */
-    void StartThread(const DeviceState &state);
+    void StartThread(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Exits the current thread
      * @url https://switchbrew.org/wiki/SVC#ExitThread
      */
-    void ExitThread(const DeviceState &state);
+    void ExitThread(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Sleep for a specified amount of time, or yield thread
      * @url https://switchbrew.org/wiki/SVC#SleepThread
      */
-    void SleepThread(const DeviceState &state);
+    void SleepThread(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Get priority of provided thread handle
      * @url https://switchbrew.org/wiki/SVC#GetThreadPriority
      */
-    void GetThreadPriority(const DeviceState &state);
+    void GetThreadPriority(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Set priority of provided thread handle
      * @url https://switchbrew.org/wiki/SVC#SetThreadPriority
      */
-    void SetThreadPriority(const DeviceState &state);
+    void SetThreadPriority(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Get core mask of provided thread handle
      * @url https://switchbrew.org/wiki/SVC#GetThreadCoreMask
      */
-    void GetThreadCoreMask(const DeviceState &state);
+    void GetThreadCoreMask(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Set core mask of provided thread handle
      * @url https://switchbrew.org/wiki/SVC#SetThreadCoreMask
      */
-    void SetThreadCoreMask(const DeviceState &state);
+    void SetThreadCoreMask(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Returns the core on which the current thread is running
      * @url https://switchbrew.org/wiki/SVC#GetCurrentProcessorNumber
      */
-    void GetCurrentProcessorNumber(const DeviceState &state);
+    void GetCurrentProcessorNumber(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Resets a KEvent to its unsignalled state
      * @url https://switchbrew.org/wiki/SVC#ClearEvent
      */
-    void ClearEvent(const DeviceState &state);
+    void ClearEvent(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Maps shared memory into a memory region
      * @url https://switchbrew.org/wiki/SVC#MapSharedMemory
      */
-    void MapSharedMemory(const DeviceState &state);
+    void MapSharedMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Unmaps shared memory which has been mapped
      * @url https://switchbrew.org/wiki/SVC#UnmapSharedMemory
      */
-    void UnmapSharedMemory(const DeviceState &state);
+    void UnmapSharedMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Returns a handle to a KTransferMemory object
      * @url https://switchbrew.org/wiki/SVC#CreateTransferMemory
      */
-    void CreateTransferMemory(const DeviceState &state);
+    void CreateTransferMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Closes the specified handle
      * @url https://switchbrew.org/wiki/SVC#CloseHandle
      */
-    void CloseHandle(const DeviceState &state);
+    void CloseHandle(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Resets a particular KEvent or KProcess which is signalled
      * @url https://switchbrew.org/wiki/SVC#ResetSignal
      */
-    void ResetSignal(const DeviceState &state);
+    void ResetSignal(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Stalls a thread till a KSyncObject signals or the timeout has ended
      * @url https://switchbrew.org/wiki/SVC#WaitSynchronization
      */
-    void WaitSynchronization(const DeviceState &state);
+    void WaitSynchronization(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief If the referenced thread is currently in a synchronization call, that call will be interrupted
      * @url https://switchbrew.org/wiki/SVC#CancelSynchronization
      */
-    void CancelSynchronization(const DeviceState &state);
+    void CancelSynchronization(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Locks a specified mutex
      * @url https://switchbrew.org/wiki/SVC#ArbitrateLock
      */
-    void ArbitrateLock(const DeviceState &state);
+    void ArbitrateLock(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Unlocks a specified mutex
      * @url https://switchbrew.org/wiki/SVC#ArbitrateUnlock
      */
-    void ArbitrateUnlock(const DeviceState &state);
+    void ArbitrateUnlock(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Waits on a process-wide key (Conditional-Variable)
      * @url https://switchbrew.org/wiki/SVC#WaitProcessWideKeyAtomic
      */
-    void WaitProcessWideKeyAtomic(const DeviceState &state);
+    void WaitProcessWideKeyAtomic(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Signals a process-wide key (Conditional-Variable)
      * @url https://switchbrew.org/wiki/SVC#SignalProcessWideKey
      */
-    void SignalProcessWideKey(const DeviceState &state);
+    void SignalProcessWideKey(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Returns the value of CNTPCT_EL0 on the Switch
      * @url https://switchbrew.org/wiki/SVC#GetSystemTick
      */
-    void GetSystemTick(const DeviceState &state);
+    void GetSystemTick(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Connects to a named IPC port
      * @url https://switchbrew.org/wiki/SVC#ConnectToNamedPort
      */
-    void ConnectToNamedPort(const DeviceState &state);
+    void ConnectToNamedPort(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Send a synchronous IPC request to a service
      * @url https://switchbrew.org/wiki/SVC#SendSyncRequest
      */
-    void SendSyncRequest(const DeviceState &state);
+    void SendSyncRequest(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Retrieves the PID of a specific thread
      * @url https://switchbrew.org/wiki/SVC#GetThreadId
      */
-    void GetThreadId(const DeviceState &state);
+    void GetThreadId(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Causes the debugger to be engaged or the program to end if it isn't being debugged
      * @url https://switchbrew.org/wiki/SVC#Break
      */
-    void Break(const DeviceState &state);
+    void Break(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Outputs a debug string
      * @url https://switchbrew.org/wiki/SVC#OutputDebugString
      */
-    void OutputDebugString(const DeviceState &state);
+    void OutputDebugString(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Retrieves a piece of information
      * @url https://switchbrew.org/wiki/SVC#GetInfo
      */
-    void GetInfo(const DeviceState &state);
+    void GetInfo(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Maps physical memory to a part of virtual memory
      * @url https://switchbrew.org/wiki/SVC#MapPhysicalMemory
      */
-    void MapPhysicalMemory(const DeviceState &state);
+    void MapPhysicalMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Unmaps previously mapped physical memory
      * @url https://switchbrew.org/wiki/SVC#UnmapPhysicalMemory
      */
-    void UnmapPhysicalMemory(const DeviceState &state);
+    void UnmapPhysicalMemory(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Sets if a thread is runnable or paused
      * @url https://switchbrew.org/wiki/SVC#SetThreadActivity
      */
-    void SetThreadActivity(const DeviceState &state);
+    void SetThreadActivity(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Gets the context structure of a paused thread
      * @url https://switchbrew.org/wiki/SVC#GetThreadContext3
      */
-    void GetThreadContext3(const DeviceState &state);
+    void GetThreadContext3(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Waits on an address based on the value of the address
      * @url https://switchbrew.org/wiki/SVC#WaitForAddress
      */
-    void WaitForAddress(const DeviceState &state);
+    void WaitForAddress(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief Signals a thread which is waiting on an address
      * @url https://switchbrew.org/wiki/SVC#SignalToAddress
      */
-    void SignalToAddress(const DeviceState &state);
+    void SignalToAddress(const DeviceState &state, SvcContext &ctx);
 
     /**
      * @brief A per-SVC descriptor with it's name and a function pointer
      * @note The descriptor is nullable, the validity of the descriptor can be checked with the boolean operator
      */
     struct SvcDescriptor {
-        void (*function)(const DeviceState &); //!< A function pointer to a HLE implementation of the SVC
-        const char* name; //!< A pointer to a static string of the SVC name, the underlying data should not be mutated
+        void (*function)(const DeviceState &, SvcContext &); //!< A function pointer to a HLE implementation of the SVC
+        const char *name; //!< A pointer to a static string of the SVC name, the underlying data should not be mutated
 
         operator bool() {
             return function;

--- a/app/src/main/cpp/skyline/kernel/svc_context.h
+++ b/app/src/main/cpp/skyline/kernel/svc_context.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2023 Strato Team and Contributors (https://github.com/strato-emu/)
+
+#pragma once
+
+#include <common/base.h>
+#include <common/wregister.h>
+
+namespace skyline::kernel::svc {
+    /**
+     * @brief Register context for SVCs
+     * @note This is used to abstract register access for SVCs, allowing for them to be called seamlessly from NCE or JIT
+     * @details Binary layout of this struct must be kept equal to NCE's ThreadContext
+     */
+    struct SvcContext {
+        union {
+            std::array<u64, 6> regs;
+            struct {
+                u64 x0, x1, x2, x3, x4, x5;
+            };
+            struct {
+                WRegister w0, w1, w2, w3, w4, w5;
+            };
+        };
+    };
+}

--- a/app/src/main/cpp/skyline/nce.cpp
+++ b/app/src/main/cpp/skyline/nce.cpp
@@ -29,7 +29,8 @@ namespace skyline::nce {
         try {
             if (svc) [[likely]] {
                 TRACE_EVENT("kernel", perfetto::StaticString{svc.name});
-                (svc.function)(state);
+                auto &svcContext{*reinterpret_cast<kernel::svc::SvcContext *>(ctx)};
+                (svc.function)(state, svcContext);
             } else {
                 throw exception("Unimplemented SVC 0x{:X}", svcId);
             }

--- a/app/src/main/cpp/skyline/nce/guest.h
+++ b/app/src/main/cpp/skyline/nce/guest.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <common.h>
+#include <common/wregister.h>
 
 namespace skyline {
     struct DeviceState;
@@ -11,20 +12,6 @@ namespace skyline {
         constexpr u64 SkyTlsMagic{util::MakeMagic<u64>("SKYTLS")};
     }
     namespace nce {
-        struct WRegister {
-            u32 lower;
-            u32 upper;
-
-            constexpr operator u32() {
-                return lower;
-            }
-
-            void operator=(u32 value) {
-                lower = value;
-                upper = 0;
-            }
-        };
-
         /**
          * @brief The state of callee-saved general purpose registers in the guest
          * @note Read about ARMv8 registers here: https://developer.arm.com/architectures/learn-the-architecture/armv8-a-instruction-set-architecture/registers-in-aarch64-general-purpose-registers


### PR DESCRIPTION
`SvcContext` represents a common interface for accessing registers from SVCs, decoupling them from a particular thread context.

> With 32-bit processes using the same SVCs as 64-bit ones but with different thread contexts, we needed a way to decouple register access from the SVC implementations to avoid duplicating them. We came up with `SvcContext`, a structure containing only the minimal amount of registers needed by SVCs. SVCs were then refactored to operate on that structure, resulting in minimal code changes for supporting 32-bit SVCs.