### PR TITLE
due to the yuzu-emu project is closed, use suyu-emu/sirit to instead …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/ericniebler/range-v3
 [submodule "Sirit"]
 	path = app/libraries/sirit
-	url = https://github.com/yuzu-emu/sirit
+	url = https://gitlab.com/suyu-emu/sirit
 [submodule "Shader Compiler"]
 	path = app/libraries/shader-compiler
 	url = https://github.com/strato-emu/shader-compiler.git


### PR DESCRIPTION
the suyu-emu/sirit project should replace the original yuzu-emu/sirit, because the yuzu-emu project is closed, we cannot get the source anymore