### PR TITLE
Update .gitmodules yuzu fork last day before they went down

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/ericniebler/range-v3
 [submodule "Sirit"]
 	path = app/libraries/sirit
-	url = https://github.com/yuzu-emu/sirit
+	url = https://github.com/steel101/Sirit
 [submodule "Shader Compiler"]
 	path = app/libraries/shader-compiler
 	url = https://github.com/strato-emu/shader-compiler.git


### PR DESCRIPTION
I forked yuzu the day before it went down I just made this repository available to the Public. This is the last link I'm submitting to you. I hope you accept this change. I would like it if you forked the repository to host it on your GitHub. Provided the last revision yuzu had before they took down there GitHub. 